### PR TITLE
Change presentation of apps in the incomplete state

### DIFF
--- a/src/app/shared/components/application-state/application-state-icon/application-state-icon.pipe.ts
+++ b/src/app/shared/components/application-state/application-state-icon/application-state-icon.pipe.ts
@@ -34,6 +34,8 @@ export class ApplicationStateIconPipe implements PipeTransform {
         return this.result(args, value, 'text-success', 'lens');
       case 'tentative':
         return this.result(args, value, 'text-tentative', 'lens');
+      case 'incomplete':
+        return this.result(args, value, 'text-tentative', 'broken_image');
       case 'warning':
         return this.result(args, value, 'text-warning', 'warning');
       case 'error':

--- a/src/app/shared/components/application-state/application-state.service.ts
+++ b/src/app/shared/components/application-state/application-state.service.ts
@@ -21,7 +21,7 @@ export class ApplicationStateService {
  *   - N - must be >0
  *   - ? - matches when the value is not known
  *
- * To determine the incompelete state, we also need to look at the package_updated_at field
+ * To determine the incomplete state, we also need to look at the package_updated_at field
  *
  */
   private stateMetadata = {
@@ -58,7 +58,7 @@ export class ApplicationStateService {
       },
       '*NONE*': {
         label: 'Incomplete',
-        indicator: 'warning',
+        indicator: 'incomplete',
         actions: 'delete,cli'
       }
     },

--- a/src/app/shared/components/card-status/card-status.component.html
+++ b/src/app/shared/components/card-status/card-status.component.html
@@ -1,5 +1,7 @@
 <div class="app-card-status"
   [ngClass]="{'app-card-status__ok': (status === 'ok'),
   'app-card-status__warning': (status === 'warning'),
+  'app-card-status__tentative': (status === 'tentative'),
+  'app-card-status__incomplete': (status === 'incomplete'),
   'app-card-status__error': (status === 'error')}"
 ></div>

--- a/src/app/shared/components/card-status/card-status.component.theme.scss
+++ b/src/app/shared/components/card-status/card-status.component.theme.scss
@@ -16,5 +16,15 @@
     &__error {
       background-color: map-get($status-colors, danger);
     }
+
+    &__tentative {
+      background-color: map-get($status-colors, tentative);
+    }
+
+    &__incomplete {
+      background-color: map-get($status-colors, tentative);
+    }
+    
+
   }
 }


### PR DESCRIPTION
Use the grey colour and a different icon for incomplete apps - tone down the warning for this status.