### PR TITLE
Reduce the size of the table header and paginator text

### DIFF
--- a/src/sass/components/mat-table.scss
+++ b/src/sass/components/mat-table.scss
@@ -1,0 +1,8 @@
+$mat-table-header-paginator-font-size: 13px;
+.mat-header-cell {
+  font-size: $mat-table-header-paginator-font-size;
+}
+
+.mat-paginator {
+  font-size: $mat-table-header-paginator-font-size;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,7 @@
 @import './sass/components/card-wall';
 @import './sass/components/mat-card';
 @import './sass/components/mat-tabs';
+@import './sass/components/mat-table';
 body {
   margin: 0;
   font-family: Lato, sans-serif; // font-size: 13px;


### PR DESCRIPTION
- Open for debate
- This departs from the 12pt guidelines in https://material.io/guidelines/components/data-tables.html#data-tables-structure
- Makes header and paginator stand out more. Paginator especially gets lost