### PR TITLE
Updated log in text

### DIFF
--- a/src/frontend/app/custom/suse-login/suse-login.component.html
+++ b/src/frontend/app/custom/suse-login/suse-login.component.html
@@ -5,7 +5,7 @@
   <div class="suse-login__content" [ngClass]="{'suse-login-sso': ssoLogin}">
     <div class="suse-login__intro">
       <h1 class="suse-login__headline">SUSE Stratos<br>Cloud Foundry<br>Console</h1>
-      <p class="suse-login__tagline">Use SUSE Stratos to develop, compose, and manage Cloud Foundry workloads.</p>
+      <p class="suse-login__tagline">Use SUSE Stratos to manage Cloud Foundry and Kubernetes systems and workloads.</p>
     </div>
     <div class="suse-login__box" [ngClass]="{'suse-login__busy': busy$ | async }">
       <div *ngIf="!ssoLogin" class="suse-login__form-title">Sign in</div>


### PR DESCRIPTION
- From `Use SUSE Stratos to develop, compose, and manage Cloud Foundry workloads.`
- To `Use SUSE Stratos to manage Cloud Foundry and Kubernetes systems and workloads.`

Fixes #75 