### PR TITLE
List fix when missing default order, added kube table filtering & default and other improvements

### DIFF
--- a/src/frontend/app/custom/kubernetes/helm-release/helm-release-pods-tab/helm-release-pods-tab.component.ts
+++ b/src/frontend/app/custom/kubernetes/helm-release/helm-release-pods-tab/helm-release-pods-tab.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
 import { HelmReleasePodsListConfigService } from '../../list-types/helm-release-pods/helm-release-pods-list-config.service';
 import { KubernetesEndpointService } from '../../services/kubernetes-endpoint.service';
+
 @Component({
   selector: 'app-helm-release-pods-tab',
   templateUrl: './helm-release-pods-tab.component.html',
@@ -12,5 +14,5 @@ import { KubernetesEndpointService } from '../../services/kubernetes-endpoint.se
   }]
 })
 export class HelmReleasePodsTabComponent {
-  constructor(public kubeEndpointService: KubernetesEndpointService) {}
+  constructor(public kubeEndpointService: KubernetesEndpointService) { }
 }

--- a/src/frontend/app/custom/kubernetes/helm-release/helm-release-pods-tab/helm-release-pods-tab.component.ts
+++ b/src/frontend/app/custom/kubernetes/helm-release/helm-release-pods-tab/helm-release-pods-tab.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 import { ListConfig } from '../../../../shared/components/list/list.component.types';
 import { HelmReleasePodsListConfigService } from '../../list-types/helm-release-pods/helm-release-pods-list-config.service';
-import { KubernetesEndpointService } from '../../services/kubernetes-endpoint.service';
 
 @Component({
   selector: 'app-helm-release-pods-tab',
@@ -13,6 +12,4 @@ import { KubernetesEndpointService } from '../../services/kubernetes-endpoint.se
     useClass: HelmReleasePodsListConfigService,
   }]
 })
-export class HelmReleasePodsTabComponent {
-  constructor(public kubeEndpointService: KubernetesEndpointService) { }
-}
+export class HelmReleasePodsTabComponent { }

--- a/src/frontend/app/custom/kubernetes/list-types/helm-release-pods/helm-release-pods-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/helm-release-pods/helm-release-pods-data-source.ts
@@ -27,7 +27,8 @@ export class HelmReleasePodsDataSource extends ListDataSource<KubernetesPod, any
       getRowUniqueId: object => object.name,
       paginationKey: action.paginationKey,
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/helm-release-pods/helm-release-pods-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/helm-release-pods/helm-release-pods-list-config.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
+
 import { AppState } from '../../../../store/app-state';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
 import { HelmReleaseService } from '../../services/helm-release.service';
 import { KubernetesPodsListConfigService } from '../kubernetes-pods/kubernetes-pods-list-config.service';
 import { HelmReleasePodsDataSource } from './helm-release-pods-data-source';
-import { PodNameLinkComponent } from '../kubernetes-pods/pod-name-link/pod-name-link.component';
 
 
 @Injectable()

--- a/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-data-source.ts
@@ -29,7 +29,8 @@ export class HelmReleaseServicesDataSource extends ListDataSource<KubeService, a
       transformEntity: map((pods: KubeService[]) =>
         pods.filter(p => p.metadata.labels && p.metadata.labels.release === helmReleaseService.helmReleaseName)),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-list-config.service.ts
@@ -1,16 +1,14 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
 import { Store } from '@ngrx/store';
 
 import { ITableColumn } from '../../../../shared/components/list/list-table/table.types';
 import { IListConfig, ListViewTypes } from '../../../../shared/components/list/list.component.types';
 import { AppState } from '../../../../store/app-state';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { KubeService } from '../../store/kube.types';
-import { HelmReleaseServicesDataSource } from './helm-release-services-data-source';
 import { HelmReleaseService } from '../../services/helm-release.service';
+import { KubeService } from '../../store/kube.types';
 import { KubernetesPodTagsComponent } from '../kubernetes-pods/kubernetes-pod-tags/kubernetes-pod-tags.component';
+import { HelmReleaseServicesDataSource } from './helm-release-services-data-source';
 
 @Injectable()
 export class HelmReleaseServicesListConfig implements IListConfig<KubeService> {
@@ -44,7 +42,11 @@ export class HelmReleaseServicesListConfig implements IListConfig<KubeService> {
 
   pageSizeOptions = [9, 45, 90];
   viewType = ListViewTypes.TABLE_ONLY;
-  enableTextFilter = false;
+  enableTextFilter = true;
+  text = {
+    filter: 'Filter by Name',
+    noEntries: 'There are no services'
+  };
 
   getGlobalActions = () => null;
   getMultiActions = () => [];
@@ -54,11 +56,11 @@ export class HelmReleaseServicesListConfig implements IListConfig<KubeService> {
   getMultiFiltersConfigs = () => [];
 
   constructor(
-    private store: Store<AppState>,
-    private kubeId: BaseKubeGuid,
-    private helmReleaseService: HelmReleaseService
+    store: Store<AppState>,
+    kubeId: BaseKubeGuid,
+    helmReleaseService: HelmReleaseService
   ) {
-    this.podsDataSource = new HelmReleaseServicesDataSource(this.store, this.kubeId, this, this.helmReleaseService);
+    this.podsDataSource = new HelmReleaseServicesDataSource(store, kubeId, this, helmReleaseService);
   }
 
 }

--- a/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/helm-release-services/helm-release-services-list-config.service.ts
@@ -25,7 +25,7 @@ export class HelmReleaseServicesListConfig implements IListConfig<KubeService> {
       sort: {
         type: 'sort',
         orderKey: 'name',
-        field: 'name'
+        field: 'metadata.name'
       },
       cellFlex: '5',
     },

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-apps/kubernetes-apps-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-apps/kubernetes-apps-data-source.ts
@@ -25,7 +25,8 @@ export class KubernetesAppsDataSource extends ListDataSource<KubernetesApp, any>
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesAppsSchemaKey, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-apps/kubernetes-apps-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-apps/kubernetes-apps-list-config.service.ts
@@ -1,16 +1,14 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
 import { Store } from '@ngrx/store';
 
 import { ITableColumn } from '../../../../shared/components/list/list-table/table.types';
 import { IListConfig, ListViewTypes } from '../../../../shared/components/list/list.component.types';
 import { AppState } from '../../../../store/app-state';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { KubernetesAppsDataSource } from './kubernetes-apps-data-source';
 import { KubernetesApp } from '../../store/kube.types';
 import { AppLinkComponent } from './app-link/app-link.component';
 import { KubeAppcreatedDateComponent } from './kube-appcreated-date/kube-appcreated-date.component';
+import { KubernetesAppsDataSource } from './kubernetes-apps-data-source';
 
 @Injectable()
 export class KubernetesAppsListConfigService implements IListConfig<KubernetesApp> {
@@ -78,7 +76,11 @@ export class KubernetesAppsListConfigService implements IListConfig<KubernetesAp
   pageSizeOptions = [9, 45, 90];
   viewType = ListViewTypes.TABLE_ONLY;
 
-  enableTextFilter = false;
+  enableTextFilter = true;
+  text = {
+    filter: 'Filter by Name',
+    noEntries: 'There are no applications'
+  };
 
   getGlobalActions = () => null;
   getMultiActions = () => [];
@@ -88,11 +90,10 @@ export class KubernetesAppsListConfigService implements IListConfig<KubernetesAp
   getMultiFiltersConfigs = () => [];
 
   constructor(
-    private store: Store<AppState>,
-    private activatedRoute: ActivatedRoute,
-    private kubeId: BaseKubeGuid,
+    store: Store<AppState>,
+    kubeId: BaseKubeGuid,
   ) {
-    this.AppsDataSource = new KubernetesAppsDataSource(this.store, kubeId, this);
+    this.AppsDataSource = new KubernetesAppsDataSource(store, kubeId, this);
   }
 
 }

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespace-pods/kubernetes-namespace-pods-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespace-pods/kubernetes-namespace-pods-data-source.ts
@@ -6,10 +6,9 @@ import { getPaginationKey } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
 import { entityFactory, kubernetesPodsSchemaKey } from '../../../../store/helpers/entity-factory';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { KubernetesNodeService } from '../../services/kubernetes-node.service';
+import { KubernetesNamespaceService } from '../../services/kubernetes-namespace.service';
 import { KubernetesPod } from '../../store/kube.types';
 import { GetKubernetesPodsInNamespace } from '../../store/kubernetes.actions';
-import { KubernetesNamespaceService } from '../../services/kubernetes-namespace.service';
 
 export class KubernetesNamespacePodsDataSource extends ListDataSource<KubernetesPod, any> {
 
@@ -26,7 +25,8 @@ export class KubernetesNamespacePodsDataSource extends ListDataSource<Kubernetes
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesPodsSchemaKey, kubeNamespaceService.namespaceName, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-data-source.ts
@@ -24,7 +24,8 @@ export class KubernetesNamespacesDataSource extends ListDataSource<KubernetesNam
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesNamespacesSchemaKey, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-data-source.ts
@@ -4,12 +4,10 @@ import { ListDataSource } from '../../../../shared/components/list/data-sources-
 import { IListConfig } from '../../../../shared/components/list/list.component.types';
 import { getPaginationKey } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
+import { entityFactory, kubernetesNamespacesSchemaKey } from '../../../../store/helpers/entity-factory';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { GetKubernetesNamespaces } from '../../store/kubernetes.actions';
-
-import { map } from 'rxjs/operators';
-import { entityFactory, kubernetesPodsSchemaKey, kubernetesNamespacesSchemaKey } from '../../../../store/helpers/entity-factory';
 import { KubernetesNamespace } from '../../store/kube.types';
+import { GetKubernetesNamespaces } from '../../store/kubernetes.actions';
 
 
 export class KubernetesNamespacesDataSource extends ListDataSource<KubernetesNamespace, any> {
@@ -24,7 +22,6 @@ export class KubernetesNamespacesDataSource extends ListDataSource<KubernetesNam
       action: new GetKubernetesNamespaces(kubeGuid.guid),
       schema: entityFactory(kubernetesNamespacesSchemaKey),
       getRowUniqueId: object => object.name,
-      //   getEmptyType: () => ({ name: '', value: '', }),
       paginationKey: getPaginationKey(kubernetesNamespacesSchemaKey, kubeGuid.guid),
       isLocal: true,
       listConfig

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-list-config.service.ts
@@ -49,7 +49,11 @@ export class KubernetesNamespacesListConfigService implements IListConfig<Kubern
 
   pageSizeOptions = [9, 45, 90];
   viewType = ListViewTypes.TABLE_ONLY;
-  enableTextFilter = false;
+  enableTextFilter = true;
+  text = {
+    filter: 'Filter by Name',
+    noEntries: 'There are no namespaces'
+  };
 
   getGlobalActions = () => null;
   getMultiActions = () => [];

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-list-config.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 
 import {
@@ -10,8 +9,8 @@ import { ITableColumn } from '../../../../shared/components/list/list-table/tabl
 import { IListConfig, ListViewTypes } from '../../../../shared/components/list/list.component.types';
 import { AppState } from '../../../../store/app-state';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { KubernetesNamespaceLinkComponent } from './kubernetes-namespace-link/kubernetes-namespace-link.component';
 import { KubeNamespacePodCountComponent } from './kube-namespace-pod-count/kube-namespace-pod-count.component';
+import { KubernetesNamespaceLinkComponent } from './kubernetes-namespace-link/kubernetes-namespace-link.component';
 
 
 @Injectable()
@@ -60,11 +59,10 @@ export class KubernetesNamespacesListConfigService implements IListConfig<Kubern
   getMultiFiltersConfigs = () => [];
 
   constructor(
-    private store: Store<AppState>,
-    private activatedRoute: ActivatedRoute,
-    private kubeId: BaseKubeGuid,
+    store: Store<AppState>,
+    kubeId: BaseKubeGuid
   ) {
-    this.podsDataSource = new KubernetesNamespacesDataSource(this.store, kubeId, this);
+    this.podsDataSource = new KubernetesNamespacesDataSource(store, kubeId, this);
   }
 
 }

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-node-pods/kubernetes-node-pods-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-node-pods/kubernetes-node-pods-data-source.ts
@@ -4,15 +4,11 @@ import { ListDataSource } from '../../../../shared/components/list/data-sources-
 import { IListConfig } from '../../../../shared/components/list/list.component.types';
 import { getPaginationKey } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
-import { BaseKubeGuid } from '../../kubernetes-page.types';
-import { GetKubernetesPods, GetKubernetesPodsOnNode } from '../../store/kubernetes.actions';
-
-import { map, switchMap, flatMap } from 'rxjs/operators';
 import { entityFactory, kubernetesPodsSchemaKey } from '../../../../store/helpers/entity-factory';
-import { KubernetesPod } from '../../store/kube.types';
-import { HelmReleaseService } from '../../services/helm-release.service';
-import { Observable } from 'rxjs';
+import { BaseKubeGuid } from '../../kubernetes-page.types';
 import { KubernetesNodeService } from '../../services/kubernetes-node.service';
+import { KubernetesPod } from '../../store/kube.types';
+import { GetKubernetesPodsOnNode } from '../../store/kubernetes.actions';
 
 export class KubernetesNodePodsDataSource extends ListDataSource<KubernetesPod, any> {
 
@@ -29,7 +25,8 @@ export class KubernetesNodePodsDataSource extends ListDataSource<KubernetesPod, 
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesPodsSchemaKey, kubeNodeService.nodeName, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-data-source.ts
@@ -1,15 +1,13 @@
 import { Store } from '@ngrx/store';
 
+import { KubernetesNode } from '../../../../../../../src/frontend/app/custom/kubernetes/store/kube.types';
 import { ListDataSource } from '../../../../shared/components/list/data-sources-controllers/list-data-source';
 import { IListConfig } from '../../../../shared/components/list/list.component.types';
 import { getPaginationKey } from '../../../../store/actions/pagination.actions';
 import { AppState } from '../../../../store/app-state';
+import { entityFactory, kubernetesNodesSchemaKey } from '../../../../store/helpers/entity-factory';
 import { BaseKubeGuid } from '../../kubernetes-page.types';
 import { GetKubernetesNodes } from '../../store/kubernetes.actions';
-
-import { map } from 'rxjs/operators';
-import { entityFactory, kubernetesNodesSchemaKey } from '../../../../store/helpers/entity-factory';
-import { KubernetesNode } from '../../../../../../../src/frontend/app/custom/kubernetes/store/kube.types';
 
 export class KubernetesNodesDataSource extends ListDataSource<KubernetesNode, any> {
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-data-source.ts
@@ -23,7 +23,8 @@ export class KubernetesNodesDataSource extends ListDataSource<KubernetesNode, an
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesNodesSchemaKey, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-list-config.service.ts
@@ -71,7 +71,11 @@ export class KubernetesNodesListConfigService implements IListConfig<KubernetesN
   pageSizeOptions = [9, 45, 90];
   viewType = ListViewTypes.TABLE_ONLY;
 
-  enableTextFilter = false;
+  enableTextFilter = true;
+  text = {
+    filter: 'Filter by Name',
+    noEntries: 'There are no nodes'
+  };
 
   getGlobalActions = () => null;
   getMultiActions = () => [];
@@ -81,10 +85,10 @@ export class KubernetesNodesListConfigService implements IListConfig<KubernetesN
   getMultiFiltersConfigs = () => [];
 
   constructor(
-    private store: Store<AppState>,
-    private kubeId: BaseKubeGuid,
+    store: Store<AppState>,
+    kubeId: BaseKubeGuid,
   ) {
-    this.nodesDataSource = new KubernetesNodesDataSource(this.store, this.kubeId, this);
+    this.nodesDataSource = new KubernetesNodesDataSource(store, kubeId, this);
   }
 
 }

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-pods/kubernetes-pods-data-source.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-pods/kubernetes-pods-data-source.ts
@@ -24,7 +24,8 @@ export class KubernetesPodsDataSource extends ListDataSource<KubernetesPod, any>
       getRowUniqueId: object => object.name,
       paginationKey: getPaginationKey(kubernetesPodsSchemaKey, kubeGuid.guid),
       isLocal: true,
-      listConfig
+      listConfig,
+      transformEntities: [{ type: 'filter', field: 'metadata.name' }]
     });
   }
 

--- a/src/frontend/app/custom/kubernetes/list-types/kubernetes-pods/kubernetes-pods-list-config.service.ts
+++ b/src/frontend/app/custom/kubernetes/list-types/kubernetes-pods/kubernetes-pods-list-config.service.ts
@@ -87,7 +87,11 @@ export class KubernetesPodsListConfigService implements IListConfig<KubernetesPo
 
   pageSizeOptions = [9, 45, 90];
   viewType = ListViewTypes.TABLE_ONLY;
-  enableTextFilter = false;
+  enableTextFilter = true;
+  text = {
+    filter: 'Filter by Name',
+    noEntries: 'There are no pods'
+  };
 
   getGlobalActions = () => null;
   getMultiActions = () => [];
@@ -97,10 +101,10 @@ export class KubernetesPodsListConfigService implements IListConfig<KubernetesPo
   getMultiFiltersConfigs = () => [];
 
   constructor(
-    private store: Store<AppState>,
+    store: Store<AppState>,
     kubeId: BaseKubeGuid,
   ) {
-    this.podsDataSource = new KubernetesPodsDataSource(this.store, kubeId, this);
+    this.podsDataSource = new KubernetesPodsDataSource(store, kubeId, this);
   }
 
 }

--- a/src/frontend/app/custom/kubernetes/services/helm-release.service.ts
+++ b/src/frontend/app/custom/kubernetes/services/helm-release.service.ts
@@ -1,23 +1,18 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { filter, map, share, tap, first } from 'rxjs/operators';
-import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
+import { filter, first, map, share } from 'rxjs/operators';
 
+import { kubernetesServicesSchemaKey } from '../../../../../../src/frontend/app/store/helpers/entity-factory';
 import { getIdFromRoute } from '../../../features/cloud-foundry/cf.helpers';
 import { PaginationMonitorFactory } from '../../../shared/monitors/pagination-monitor.factory';
 import { AppState } from '../../../store/app-state';
-import {
-  entityFactory,
-  kubernetesAppsSchemaKey,
-  kubernetesDeploymentsSchemaKey,
-  kubernetesStatefulSetsSchemaKey,
-} from '../../../store/helpers/entity-factory';
+import { entityFactory, kubernetesAppsSchemaKey } from '../../../store/helpers/entity-factory';
 import { getPaginationObservables } from '../../../store/reducers/pagination-reducer/pagination-reducer.helper';
-import { KubernetesApp, KubernetesDeployment, KubernetesStatefuleSet, KubernetesPod, KubeService } from '../store/kube.types';
-import { GeKubernetesDeployments, GetKubernetesApps, GetKubernetesStatefulSets, GetKubernetesServices } from '../store/kubernetes.actions';
+import { KubernetesApp, KubernetesDeployment, KubernetesPod, KubernetesStatefulSet, KubeService } from '../store/kube.types';
+import { GetKubernetesApps, GetKubernetesServices } from '../store/kubernetes.actions';
 import { KubernetesEndpointService } from './kubernetes-endpoint.service';
-import { kubernetesServicesSchemaKey } from '../../../../../../src/frontend/app/store/helpers/entity-factory';
 
 @Injectable()
 export class HelmReleaseService {
@@ -25,8 +20,8 @@ export class HelmReleaseService {
   helmReleaseName: string;
   helmRelease$: Observable<KubernetesApp>;
   deployments$: Observable<KubernetesDeployment[]>;
-  statefulSets$: Observable<KubernetesStatefuleSet[]>;
-  services$:  Observable<KubeService[]>;
+  statefulSets$: Observable<KubernetesStatefulSet[]>;
+  services$: Observable<KubeService[]>;
 
   constructor(
     public kubeEndpointService: KubernetesEndpointService,

--- a/src/frontend/app/custom/kubernetes/services/kubernetes-endpoint.service.ts
+++ b/src/frontend/app/custom/kubernetes/services/kubernetes-endpoint.service.ts
@@ -20,7 +20,7 @@ import { getPaginationObservables } from '../../../store/reducers/pagination-red
 import { EntityInfo } from '../../../store/types/api.types';
 import { EndpointModel, EndpointUser } from '../../../store/types/endpoint.types';
 import { BaseKubeGuid } from '../kubernetes-page.types';
-import { KubernetesDeployment, KubernetesStatefuleSet, KubeService, KubernetesPod } from '../store/kube.types';
+import { KubernetesDeployment, KubernetesStatefulSet, KubeService, KubernetesPod } from '../store/kube.types';
 import {
   GeKubernetesDeployments,
   GetKubernetesServices,
@@ -40,7 +40,7 @@ export class KubernetesEndpointService {
   currentUser$: Observable<EndpointUser>;
   kubeGuid: string;
   deployments$: Observable<KubernetesDeployment[]>;
-  statefulSets$: Observable<KubernetesStatefuleSet[]>;
+  statefulSets$: Observable<KubernetesStatefulSet[]>;
   services$: Observable<KubeService[]>;
   pods$: Observable<KubernetesPod[]>;
 
@@ -81,7 +81,7 @@ export class KubernetesEndpointService {
       kubernetesPodsSchemaKey
     );
 
-    this.statefulSets$ = this.getObservable<KubernetesStatefuleSet>(
+    this.statefulSets$ = this.getObservable<KubernetesStatefulSet>(
       new GetKubernetesStatefulSets(this.kubeGuid),
       kubernetesStatefulSetsSchemaKey
     );
@@ -94,7 +94,7 @@ export class KubernetesEndpointService {
 
   }
 
-  private getObservable<T>(pagintionAction: KubePaginationAction, schemaKey: string ): Observable<T[]> {
+  private getObservable<T>(pagintionAction: KubePaginationAction, schemaKey: string): Observable<T[]> {
     return getPaginationObservables<T>({
       store: this.store,
       action: pagintionAction,

--- a/src/frontend/app/custom/kubernetes/store/kube.types.ts
+++ b/src/frontend/app/custom/kubernetes/store/kube.types.ts
@@ -19,7 +19,7 @@ export interface KubeService {
   status: ServiceStatus;
   spec: DeploymentSpec;
 }
-export interface KubernetesStatefuleSet {
+export interface KubernetesStatefulSet {
   metadata: ServiceMetadata;
   status: ServiceStatus;
   spec: ServiceSpec;

--- a/src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
+++ b/src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
@@ -10,8 +10,9 @@ import {
   kubernetesServicesSchemaKey,
   kubernetesStatefulSetsSchemaKey
 } from '../../../store/helpers/entity-factory';
-import { PaginatedAction } from '../../../store/types/pagination.types';
+import { PaginatedAction, PaginationParam } from '../../../store/types/pagination.types';
 import { IRequestAction } from '../../../store/types/request.types';
+import { encodeUriQuery } from '@angular/router/src/url_tree';
 
 export const GET_RELEASE_POD_INFO = '[KUBERNETES Endpoint] Get Release Pods Info';
 export const GET_RELEASE_POD_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Release Pods Info Success';
@@ -33,7 +34,7 @@ export const GET_PODS_ON_NODE_INFO = '[KUBERNETES Endpoint] Get Pods on Node Inf
 export const GET_PODS_ON_NODE_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Pods on Node Success';
 export const GET_PODS_ON_NODE_INFO_FAILURE = '[KUBERNETES Endpoint] Get Pods on Node Failure';
 
-export const GET_PODS_IN_NAMEPSACE_INFO = '[KUBERNETES Endpoint] Get Pods in Namespace Info';
+export const GET_PODS_IN_NAMESPACE_INFO = '[KUBERNETES Endpoint] Get Pods in Namespace Info';
 export const GET_PODS_IN_NAMEPSACE_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Pods in Namespace Success';
 export const GET_PODS_IN_NAMEPSACE_INFO_FAILURE = '[KUBERNETES Endpoint] Get Pods in Namespace Failure';
 
@@ -79,7 +80,7 @@ export class GetKubernetesReleasePods implements KubePaginationAction {
       labelSelector: `app.kubernetes.io/instance=${releaseName}`
     };
   }
-  initialParams: { labelSelector: string; };
+  initialParams: PaginationParam;
   type = GET_RELEASE_POD_INFO;
   entityKey = kubernetesPodsSchemaKey;
   entity = [entityFactory(kubernetesPodsSchemaKey)];
@@ -151,6 +152,9 @@ export class GetKubernetesPods implements KubePaginationAction {
 export class GetKubernetesPodsOnNode implements PaginatedAction, KubeAction {
   constructor(public kubeGuid: string, public nodeName: string) {
     this.paginationKey = getPaginationKey(kubernetesPodsSchemaKey, nodeName, kubeGuid);
+    this.initialParams = {
+      fieldSelector: `spec.nodeName=${nodeName}`
+    };
   }
   type = GET_PODS_ON_NODE_INFO;
   entityKey = kubernetesPodsSchemaKey;
@@ -161,17 +165,18 @@ export class GetKubernetesPodsOnNode implements PaginatedAction, KubeAction {
     GET_PODS_ON_NODE_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams: PaginationParam;
 }
 
 export class GetKubernetesPodsInNamespace implements PaginatedAction, KubeAction {
   constructor(public kubeGuid: string, public namespaceName: string) {
     this.paginationKey = getPaginationKey(kubernetesPodsSchemaKey, namespaceName, kubeGuid);
   }
-  type = GET_PODS_IN_NAMEPSACE_INFO;
+  type = GET_PODS_IN_NAMESPACE_INFO;
   entityKey = kubernetesPodsSchemaKey;
   entity = [entityFactory(kubernetesPodsSchemaKey)];
   actions = [
-    GET_PODS_IN_NAMEPSACE_INFO,
+    GET_PODS_IN_NAMESPACE_INFO,
     GET_PODS_IN_NAMEPSACE_INFO_SUCCESS,
     GET_PODS_IN_NAMEPSACE_INFO_FAILURE
   ];

--- a/src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
+++ b/src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
@@ -1,4 +1,6 @@
-import { MetricsAction, MetricQueryConfig, MetricsChartAction } from '../../../store/actions/metrics.actions';
+import { SortDirection } from '@angular/material';
+
+import { MetricQueryConfig, MetricsAction, MetricsChartAction } from '../../../store/actions/metrics.actions';
 import { getPaginationKey } from '../../../store/actions/pagination.actions';
 import {
   entityFactory,
@@ -8,11 +10,10 @@ import {
   kubernetesNodesSchemaKey,
   kubernetesPodsSchemaKey,
   kubernetesServicesSchemaKey,
-  kubernetesStatefulSetsSchemaKey
+  kubernetesStatefulSetsSchemaKey,
 } from '../../../store/helpers/entity-factory';
 import { PaginatedAction, PaginationParam } from '../../../store/types/pagination.types';
 import { IRequestAction } from '../../../store/types/request.types';
-import { encodeUriQuery } from '@angular/router/src/url_tree';
 
 export const GET_RELEASE_POD_INFO = '[KUBERNETES Endpoint] Get Release Pods Info';
 export const GET_RELEASE_POD_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Release Pods Info Success';
@@ -66,6 +67,10 @@ export const GET_KUBE_DEPLOYMENT = '[KUBERNETES Endpoint] Get K8S Deployments In
 export const GET_KUBE_DEPLOYMENT_SUCCESS = '[KUBERNETES Endpoint] Get Deployments Success';
 export const GET_KUBE_DEPLOYMENT_FAILURE = '[KUBERNETES Endpoint] Get Deployments Failure';
 
+const sortPodsByName = {
+  'order-direction': 'desc' as SortDirection,
+  'order-direction-field': 'name'
+};
 
 export interface KubeAction extends IRequestAction {
   kubeGuid: string;
@@ -77,7 +82,8 @@ export class GetKubernetesReleasePods implements KubePaginationAction {
   constructor(public kubeGuid: string, releaseName: string) {
     this.paginationKey = getPaginationKey(kubernetesPodsSchemaKey, releaseName, kubeGuid);
     this.initialParams = {
-      labelSelector: `app.kubernetes.io/instance=${releaseName}`
+      labelSelector: `app.kubernetes.io/instance=${releaseName}`,
+      ...sortPodsByName
     };
   }
   initialParams: PaginationParam;
@@ -106,7 +112,12 @@ export class GetKubernetesNodes implements KubePaginationAction {
     GET_NODES_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    'order-direction': 'desc' as SortDirection,
+    'order-direction-field': 'name'
+  };
 }
+
 export class GetKubernetesNode implements KubeAction {
   constructor(public nodeName: string, public kubeGuid: string) {
   }
@@ -120,6 +131,7 @@ export class GetKubernetesNode implements KubeAction {
     GET_NODE_INFO_FAILURE
   ];
 }
+
 export class GetKubernetesNamespace implements KubeAction {
   constructor(public namespaceName: string, public kubeGuid: string) {
   }
@@ -147,13 +159,17 @@ export class GetKubernetesPods implements KubePaginationAction {
     GET_POD_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    ...sortPodsByName
+  };
 }
 
 export class GetKubernetesPodsOnNode implements PaginatedAction, KubeAction {
   constructor(public kubeGuid: string, public nodeName: string) {
     this.paginationKey = getPaginationKey(kubernetesPodsSchemaKey, nodeName, kubeGuid);
     this.initialParams = {
-      fieldSelector: `spec.nodeName=${nodeName}`
+      fieldSelector: `spec.nodeName=${nodeName}`,
+      ...sortPodsByName
     };
   }
   type = GET_PODS_ON_NODE_INFO;
@@ -181,7 +197,11 @@ export class GetKubernetesPodsInNamespace implements PaginatedAction, KubeAction
     GET_PODS_IN_NAMEPSACE_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    ...sortPodsByName
+  };
 }
+
 export class GetKubernetesNamespaces implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesNamespacesSchemaKey, kubeGuid);
@@ -195,7 +215,12 @@ export class GetKubernetesNamespaces implements KubePaginationAction {
     GET_NAMESPACES_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    'order-direction': 'desc' as SortDirection,
+    'order-direction-field': 'name'
+  };
 }
+
 export class GetKubernetesApps implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesAppsSchemaKey, kubeGuid);
@@ -209,7 +234,12 @@ export class GetKubernetesApps implements KubePaginationAction {
     GET_KUBERNETES_APP_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    'order-direction': 'desc' as SortDirection,
+    'order-direction-field': 'name'
+  };
 }
+
 export class GetKubernetesServices implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesServicesSchemaKey, kubeGuid);
@@ -223,7 +253,12 @@ export class GetKubernetesServices implements KubePaginationAction {
     GET_SERVICE_INFO_FAILURE
   ];
   paginationKey: string;
+  initialParams = {
+    'order-direction': 'desc' as SortDirection,
+    'order-direction-field': 'name'
+  };
 }
+
 export class GetKubernetesPod implements KubeAction {
   constructor(public podName, public namespaceName, public kubeGuid) {
   }
@@ -236,6 +271,7 @@ export class GetKubernetesPod implements KubeAction {
     GET_KUBE_POD_FAILURE
   ];
 }
+
 export class GetKubernetesStatefulSets implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesStatefulSetsSchemaKey, kubeGuid);
@@ -249,8 +285,8 @@ export class GetKubernetesStatefulSets implements KubePaginationAction {
     GET_KUBE_STATEFULSETS_FAILURE
   ];
   paginationKey: string;
-
 }
+
 export class GeKubernetesDeployments implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesDeploymentsSchemaKey, kubeGuid);
@@ -264,8 +300,8 @@ export class GeKubernetesDeployments implements KubePaginationAction {
     GET_KUBE_DEPLOYMENT_FAILURE
   ];
   paginationKey: string;
-
 }
+
 function getKubeMetricsAction(guid: string) {
   return `${MetricsAction.getBaseMetricsURL()}/kubernetes/${guid}`;
 }

--- a/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
+++ b/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
@@ -27,7 +27,7 @@ import {
   KubernetesNamespace,
   KubernetesNode,
   KubernetesPod,
-  KubernetesStatefuleSet,
+  KubernetesStatefulSet,
   KubeService,
   ConfigMap,
 } from './kube.types';
@@ -59,7 +59,7 @@ import {
   GetKubernetesNamespace,
   GET_NAMESPACE_INFO,
   GetKubernetesPodsInNamespace,
-  GET_PODS_IN_NAMEPSACE_INFO,
+  GET_PODS_IN_NAMESPACE_INFO,
 } from './kubernetes.actions';
 
 export type GetID<T> = (p: T) => string;
@@ -93,6 +93,7 @@ export class KubernetesEffects {
       return this.processNodeAction(action);
     })
   );
+
   @Effect()
   fetchNodeInfo$ = this.actions$.ofType<GetKubernetesNode>(GET_NODE_INFO).pipe(
     flatMap(action => {
@@ -103,6 +104,7 @@ export class KubernetesEffects {
         getUid);
     })
   );
+
   @Effect()
   fetchNamespaceInfo$ = this.actions$.ofType<GetKubernetesNamespace>(GET_NAMESPACE_INFO).pipe(
     flatMap(action => {
@@ -132,25 +134,19 @@ export class KubernetesEffects {
       return this.processListAction<KubernetesPod>(action,
         `/pp/${this.proxyAPIVersion}/proxy/api/v1/pods`,
         kubernetesPodsSchemaKey,
-        getUid,
-        (p: KubernetesPod) => {
-          return p.spec.nodeName === action.nodeName;
-        }
+        getUid
       );
     })
   );
 
   @Effect()
-  fetchPodsInNamespaceInfo$ = this.actions$.ofType<GetKubernetesPodsInNamespace>(GET_PODS_IN_NAMEPSACE_INFO).pipe(
+  fetchPodsInNamespaceInfo$ = this.actions$.ofType<GetKubernetesPodsInNamespace>(GET_PODS_IN_NAMESPACE_INFO).pipe(
     flatMap(action => {
       const getUid: GetID<KubernetesPod> = (p) => p.metadata.uid;
       return this.processListAction<KubernetesPod>(action,
-        `/pp/${this.proxyAPIVersion}/proxy/api/v1/pods`,
+        `/pp/${this.proxyAPIVersion}/proxy/api/v1/namespaces/${action.namespaceName}/pods`,
         kubernetesPodsSchemaKey,
-        getUid,
-        (p: KubernetesPod) => {
-          return p.metadata.namespace === action.namespaceName;
-        }
+        getUid
       );
     })
   );
@@ -169,7 +165,6 @@ export class KubernetesEffects {
   @Effect()
   fetchServicesInfo$ = this.actions$.ofType<GetKubernetesServices>(GET_SERVICE_INFO).pipe(
     flatMap(action => {
-
       const getUid: GetID<KubeService> = (p) => p.metadata.uid;
       return this.processListAction<KubeService>(action,
         `/pp/${this.proxyAPIVersion}/proxy/api/v1/services`,
@@ -181,22 +176,19 @@ export class KubernetesEffects {
   @Effect()
   fetchNamespacesInfo$ = this.actions$.ofType<GetKubernetesNamespaces>(GET_NAMESPACES_INFO).pipe(
     flatMap(action => {
-
       const getUid: GetID<KubernetesNamespace> = (p) => p.metadata.uid;
       return this.processListAction<KubernetesNamespace>(action,
         `/pp/${this.proxyAPIVersion}/proxy/api/v1/namespaces`,
         kubernetesNamespacesSchemaKey,
         getUid);
     })
-
   );
 
   @Effect()
   fetchStatefulSets$ = this.actions$.ofType<GetKubernetesStatefulSets>(GET_KUBE_STATEFULSETS).pipe(
     flatMap(action => {
-
-      const getUid: GetID<KubernetesStatefuleSet> = (p) => p.metadata.uid;
-      return this.processListAction<KubernetesStatefuleSet>(action,
+      const getUid: GetID<KubernetesStatefulSet> = (p) => p.metadata.uid;
+      return this.processListAction<KubernetesStatefulSet>(action,
         `/pp/${this.proxyAPIVersion}/proxy/apis/apps/v1/statefulsets`,
         kubernetesStatefulSetsSchemaKey,
         getUid);
@@ -206,7 +198,6 @@ export class KubernetesEffects {
   @Effect()
   fetchDeployments$ = this.actions$.ofType<GeKubernetesDeployments>(GET_KUBE_DEPLOYMENT).pipe(
     flatMap(action => {
-
       const getUid: GetID<KubernetesDeployment> = (p) => p.metadata.uid;
       return this.processListAction<KubernetesDeployment>(action,
         `/pp/${this.proxyAPIVersion}/proxy/apis/apps/v1/deployments`,

--- a/src/frontend/app/custom/kubernetes/tabs/kubernetes-apps-tab/kubernetes-apps-tab.component.ts
+++ b/src/frontend/app/custom/kubernetes/tabs/kubernetes-apps-tab/kubernetes-apps-tab.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit } from '@angular/core';
-import { KubernetesAppsListConfigService } from '../../list-types/kubernetes-apps/kubernetes-apps-list-config.service';
+import { Component } from '@angular/core';
+
 import { ListConfig } from '../../../../../../../src/frontend/app/shared/components/list/list.component.types';
+import { KubernetesAppsListConfigService } from '../../list-types/kubernetes-apps/kubernetes-apps-list-config.service';
 
 @Component({
   selector: 'app-kubernetes-apps-tab',
@@ -11,11 +12,4 @@ import { ListConfig } from '../../../../../../../src/frontend/app/shared/compone
     useClass: KubernetesAppsListConfigService,
   }]
 })
-export class KubernetesAppsTabComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class KubernetesAppsTabComponent { }

--- a/src/frontend/app/shared/components/list/list-table/table.types.ts
+++ b/src/frontend/app/shared/components/list/list-table/table.types.ts
@@ -44,7 +44,7 @@ export interface ITableColumn<T> {
 }
 
 export interface ITableText {
-  title: string;
+  title?: string;
   filter?: string;
   noEntries?: string;
 }

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -1,68 +1,35 @@
 import { Injectable } from '@angular/core';
-import {
-  Headers,
-  Http,
-  Request,
-  RequestOptions,
-  URLSearchParams,
-} from '@angular/http';
+import { Headers, Http, Request, RequestOptions, URLSearchParams } from '@angular/http';
 import { Actions, Effect } from '@ngrx/effects';
-import { Store, Action } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { normalize, Schema } from 'normalizr';
 import { Observable } from 'rxjs';
-import { map, mergeMap, withLatestFrom, catchError } from 'rxjs/operators';
+import { catchError, map, mergeMap, withLatestFrom } from 'rxjs/operators';
+
 import { LoggerService } from '../../core/logger.service';
 import { SendEventAction } from '../actions/internal-events.actions';
 import { endpointSchemaKey, entityFactory } from '../helpers/entity-factory';
 import { listEntityRelations } from '../helpers/entity-relations/entity-relations';
+import { EntityInlineParentAction, isEntityInlineParentAction } from '../helpers/entity-relations/entity-relations.types';
+import { CfAPIFlattener, flattenPagination } from '../helpers/paginated-request-helpers';
 import {
-  EntityInlineParentAction,
-  isEntityInlineParentAction,
-} from '../helpers/entity-relations/entity-relations.types';
-import {
-  CfAPIFlattener,
-  flattenPagination,
-} from '../helpers/paginated-request-helpers';
-import { getRequestTypeFromMethod, startApiRequest, getFailApiRequestActions } from '../reducers/api-request-reducer/request-helpers';
+  getFailApiRequestActions,
+  getRequestTypeFromMethod,
+  startApiRequest,
+} from '../reducers/api-request-reducer/request-helpers';
 import { qParamsToString } from '../reducers/pagination-reducer/pagination-reducer.helper';
-import {
-  resultPerPageParam,
-  resultPerPageParamDefault,
-} from '../reducers/pagination-reducer/pagination-reducer.types';
+import { resultPerPageParam, resultPerPageParamDefault } from '../reducers/pagination-reducer/pagination-reducer.types';
 import { selectPaginationState } from '../selectors/pagination.selectors';
 import { EndpointModel } from '../types/endpoint.types';
 import { InternalEventSeverity } from '../types/internal-events.types';
-import {
-  PaginatedAction,
-  PaginationEntityState,
-  PaginationParam,
-} from '../types/pagination.types';
-import {
-  APISuccessOrFailedAction,
-  ICFAction,
-  IRequestAction,
-  RequestEntityLocation,
-} from '../types/request.types';
+import { PaginatedAction, PaginationEntityState, PaginationParam } from '../types/pagination.types';
+import { APISuccessOrFailedAction, ICFAction, IRequestAction, RequestEntityLocation } from '../types/request.types';
 import { environment } from './../../../environments/environment';
-import {
-  ApiActionTypes,
-  ValidateEntitiesStart,
-} from './../actions/request.actions';
+import { ApiActionTypes, ValidateEntitiesStart } from './../actions/request.actions';
 import { AppState, IRequestEntityTypeState } from './../app-state';
-import {
-  APIResource,
-  instanceOfAPIResource,
-  NormalizedResponse,
-} from './../types/api.types';
-import {
-  StartRequestAction,
-  WrapperRequestActionFailed,
-} from './../types/request.types';
-import {
-  RecursiveDelete,
-  RecursiveDeleteComplete,
-  RecursiveDeleteFailed,
-} from './recursive-entity-delete.effect';
+import { APIResource, instanceOfAPIResource, NormalizedResponse } from './../types/api.types';
+import { WrapperRequestActionFailed } from './../types/request.types';
+import { RecursiveDelete, RecursiveDeleteComplete, RecursiveDeleteFailed } from './recursive-entity-delete.effect';
 
 const { proxyAPIVersion, cfAPIVersion } = environment;
 const endpointHeader = 'x-cap-cnsi-list';
@@ -106,7 +73,7 @@ export class APIEffect {
       mergeMap(([action, state]) => {
         return this.doApiRequest(action, state);
       }),
-  );
+    );
 
   private doApiRequest(action: ICFAction | PaginatedAction, state: AppState) {
     const actionClone = { ...action };
@@ -280,7 +247,7 @@ export class APIEffect {
             apiAction.guid,
             apiAction.endpointGuid,
             entityFactory(apiAction.entityKey),
-          ), );
+          ));
         }
         return errorActions;
       }),
@@ -414,7 +381,7 @@ export class APIEffect {
           data[guid] !== null &&
           errorCheck.findIndex(error => error.guid === guid && !error.error) >=
           0,
-    )
+      )
       .map(cfGuid => {
         const cfData = data[cfGuid];
         switch (apiAction.entityLocation) {

--- a/src/frontend/app/store/types/entity.types.ts
+++ b/src/frontend/app/store/types/entity.types.ts
@@ -13,7 +13,7 @@ import {
   KubernetesNamespace,
   KubernetesNode,
   KubernetesPod,
-  KubernetesStatefuleSet,
+  KubernetesStatefulSet,
 } from '../../custom/kubernetes/store/kube.types';
 import { IRequestEntityTypeState, IRequestTypeState } from '../app-state';
 import {
@@ -86,8 +86,8 @@ export interface IRequestDataState extends IRequestTypeState {
   kubernetesNamespace: IRequestEntityTypeState<KubernetesNamespace>;
   kubernetesApp: IRequestEntityTypeState<KubernetesApp>;
   kubernetesService: IRequestEntityTypeState<KubernetesService>;
-  kubernetesStatefulSet: IRequestEntityTypeState<KubernetesStatefuleSet>;
-  kubernetesDeployment: IRequestEntityTypeState<KubernetesStatefuleSet>;
+  kubernetesStatefulSet: IRequestEntityTypeState<KubernetesStatefulSet>;
+  kubernetesDeployment: IRequestEntityTypeState<KubernetesStatefulSet>;
 }
 
 export interface IRequestState extends IRequestTypeState {


### PR DESCRIPTION
List Fixes - See commit 55e42fd
- Fix change of page size when a list action does not contain initialParam sort properties
- Improve performance by ensure we don't sort/filter on page number/page size changes

Kubernetes fixes
- Fixed kube service table sort

Kubernetes improvements
- Avoid fetching all pods in namespace/node by using built in api filtering
- Apply default sort to kube tables
- Apply local filtering on name

Kubernetes tidy ups
- Fixed typo (KubernetesStatefuleSet --> KubernetesStatefulSet)
- Fixed type (GET_PODS_IN_NAMEPSACE_INFO --> GET_PODS_IN_NAMESPACE_INFO_
- Removed privates that weren't required, unused params, etc
- cleaned imports