### PR TITLE
Add validation when connecting Kubernetes endpoints

### DIFF
--- a/src/jetstream/auth.go
+++ b/src/jetstream/auth.go
@@ -424,6 +424,17 @@ func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemShare
 					"Error occurred: %s", err)
 			}
 
+			// Validate the connection - some endpoints may want to validate that the connected endpoint
+			err = endpointPlugin.Validate(userID, cnsiRecord, *tokenRecord)
+			if err != nil {
+				// Clear the token
+				p.ClearCNSIToken(cnsiRecord, userID)
+				return nil, interfaces.NewHTTPShadowError(
+					http.StatusBadRequest,
+					"Could not connect to the endpoint",
+					"Could not connect to the endpoint: %s", err)
+			}
+
 			resp := &interfaces.LoginRes{
 				Account:     userID,
 				TokenExpiry: tokenRecord.TokenExpiry,
@@ -583,18 +594,24 @@ func (p *portalProxy) logoutOfCNSI(c echo.Context) error {
 		userGUID = tokens.SystemSharedUserGuid
 	}
 
+	// Clear the token
+	return p.ClearCNSIToken(cnsiRecord, userGUID)
+}
+
+// Clear the CNSI token
+func (p *portalProxy) ClearCNSIToken(cnsiRecord interfaces.CNSIRecord, userGUID string) error {
 	// If cnsi is cf AND cf is auto-register only clear the entry
 	p.Config.AutoRegisterCFUrl = strings.TrimRight(p.Config.AutoRegisterCFUrl, "/")
 	if cnsiRecord.CNSIType == "cf" && p.GetConfig().AutoRegisterCFUrl == cnsiRecord.APIEndpoint.String() {
 		log.Debug("Setting token record as disconnected")
 
 		tokenRecord := p.InitEndpointTokenRecord(0, "cleared_token", "cleared_token", true)
-		if err := p.setCNSITokenRecord(cnsiGUID, userGUID, tokenRecord); err != nil {
+		if err := p.setCNSITokenRecord(cnsiRecord.GUID, userGUID, tokenRecord); err != nil {
 			return fmt.Errorf("Unable to clear token: %s", err)
 		}
 	} else {
 		log.Debug("Deleting Token")
-		if err := p.deleteCNSIToken(cnsiGUID, userGUID); err != nil {
+		if err := p.deleteCNSIToken(cnsiRecord.GUID, userGUID); err != nil {
 			return fmt.Errorf("Unable to delete token: %s", err)
 		}
 	}

--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -296,6 +296,31 @@ func (p *portalProxy) DoProxyRequest(requests []interfaces.ProxyRequestInfo) (ma
 	return responses, nil
 }
 
+// Convenience helper for a single request
+func (p *portalProxy) DoProxySingleRequest(cnsiGUID, userGUID, method, requestUrl string) (*interfaces.CNSIRequest, error) {
+	requests := make([]interfaces.ProxyRequestInfo, 0)
+
+	proxyURL, err := url.Parse(requestUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	req := interfaces.ProxyRequestInfo{}
+	req.UserGUID = userGUID
+	req.ResultGUID = "REQ_" + cnsiGUID
+	req.EndpointGUID = cnsiGUID
+	req.Method = method
+	req.URI = proxyURL
+	requests = append(requests, req)
+
+	responses, err := p.DoProxyRequest(requests)
+	if err != nil {
+		return nil, err
+	}
+
+	return responses[req.ResultGUID], err
+}
+
 func (p *portalProxy) SendProxiedResponse(c echo.Context, responses map[string]*interfaces.CNSIRequest) error {
 	shouldPassthrough := "true" == c.Request().Header().Get("x-cap-passthrough")
 

--- a/src/jetstream/plugins/caasp/main.go
+++ b/src/jetstream/plugins/caasp/main.go
@@ -66,6 +66,10 @@ func (m *CaaspSpecification) Register(echoContext echo.Context) error {
 	return m.portalProxy.RegisterEndpoint(echoContext, m.Info)
 }
 
+func (m *CaaspSpecification) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
+	return nil
+}
+
 func (m *CaaspSpecification) Connect(ec echo.Context, cnsiRecord interfaces.CNSIRecord, userId string) (*interfaces.TokenRecord, bool, error) {
 	log.Debug("Caasp Connect...")
 

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -55,6 +55,10 @@ func (c *CloudFoundrySpecification) Register(echoContext echo.Context) error {
 	return c.portalProxy.RegisterEndpoint(echoContext, c.Info)
 }
 
+func (c *CloudFoundrySpecification) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
+	return nil
+}
+
 func (c *CloudFoundrySpecification) Connect(ec echo.Context, cnsiRecord interfaces.CNSIRecord, userId string) (*interfaces.TokenRecord, bool, error) {
 	log.Info("CloudFoundry Connect...")
 

--- a/src/jetstream/plugins/kubernetes/main.go
+++ b/src/jetstream/plugins/kubernetes/main.go
@@ -59,6 +59,19 @@ func (c *KubernetesSpecification) Register(echoContext echo.Context) error {
 	return c.portalProxy.RegisterEndpoint(echoContext, c.Info)
 }
 
+func (c *KubernetesSpecification) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
+	response, err := c.portalProxy.DoProxySingleRequest(cnsiRecord.GUID, userGUID, "GET", "api/v1/pods")
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode >= 400 {
+		return errors.New("Unable to connect to endpoint")
+	}
+
+	return nil
+}
+
 func (c *KubernetesSpecification) Connect(ec echo.Context, cnsiRecord interfaces.CNSIRecord, userId string) (*interfaces.TokenRecord, bool, error) {
 	log.Debug("Kubernetes Connect...")
 

--- a/src/jetstream/plugins/kubernetes/main.go
+++ b/src/jetstream/plugins/kubernetes/main.go
@@ -60,7 +60,7 @@ func (c *KubernetesSpecification) Register(echoContext echo.Context) error {
 }
 
 func (c *KubernetesSpecification) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
-	response, err := c.portalProxy.DoProxySingleRequest(cnsiRecord.GUID, userGUID, "GET", "api/v1/pods")
+	response, err := c.portalProxy.DoProxySingleRequest(cnsiRecord.GUID, userGUID, "GET", "api/v1/pods?limit=1")
 	if err != nil {
 		return err
 	}

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -94,6 +94,10 @@ func (m *MetricsSpecification) Register(echoContext echo.Context) error {
 	return m.portalProxy.RegisterEndpoint(echoContext, m.Info)
 }
 
+func (m *MetricsSpecification) Validate(userGUID string, cnsiRecord interfaces.CNSIRecord, tokenRecord interfaces.TokenRecord) error {
+	return nil
+}
+
 func (m *MetricsSpecification) Connect(ec echo.Context, cnsiRecord interfaces.CNSIRecord, userId string) (*interfaces.TokenRecord, bool, error) {
 	log.Debug("Metrics Connect...")
 

--- a/src/jetstream/repository/interfaces/endpoints.go
+++ b/src/jetstream/repository/interfaces/endpoints.go
@@ -9,6 +9,7 @@ type EndpointPlugin interface {
 	GetType() string
 	Register(echoContext echo.Context) error
 	Connect(echoContext echo.Context, cnsiRecord CNSIRecord, userId string) (*TokenRecord, bool, error)
+	Validate(userGUID string, cnsiRecord CNSIRecord, tokenRecord TokenRecord) error
 	UpdateMetadata(info *Info, userGUID string, echoContext echo.Context)
 }
 

--- a/src/jetstream/repository/interfaces/portal_proxy.go
+++ b/src/jetstream/repository/interfaces/portal_proxy.go
@@ -55,6 +55,7 @@ type PortalProxy interface {
 	// Proxy API requests
 	ProxyRequest(c echo.Context, uri *url.URL) (map[string]*CNSIRequest, error)
 	DoProxyRequest(requests []ProxyRequestInfo) (map[string]*CNSIRequest, error)
+	DoProxySingleRequest(cnsiGUID, userGUID, method, requestUrl string) (*CNSIRequest, error)
 	SendProxiedResponse(c echo.Context, responses map[string]*CNSIRequest) error
 
 	AddAuthProvider(name string, provider AuthProvider)


### PR DESCRIPTION
Adds a Validate function to the endpoint plugin that is called as part of the Connect flow.

Allows an endpoint plugin to check that the authentication provided is valid.

Fixes #91 