### PR TITLE
Show error on kubernetes pages and kubernetes endpoint page.

### DIFF
--- a/src/frontend/app/custom/kubernetes/helm-release/helm-release.component.ts
+++ b/src/frontend/app/custom/kubernetes/helm-release/helm-release.component.ts
@@ -17,7 +17,7 @@ import { map } from 'rxjs/operators';
       provide: BaseKubeGuid,
       useFactory: (activatedRoute: ActivatedRoute) => {
         return {
-          guid: activatedRoute.snapshot.params.kubeId
+          guid: activatedRoute.snapshot.params.endpointId
         };
       },
       deps: [

--- a/src/frontend/app/custom/kubernetes/kubernetes-namespace/kubernetes-namespace.component.ts
+++ b/src/frontend/app/custom/kubernetes/kubernetes-namespace/kubernetes-namespace.component.ts
@@ -17,7 +17,7 @@ import { map } from 'rxjs/operators';
       provide: BaseKubeGuid,
       useFactory: (activatedRoute: ActivatedRoute) => {
         return {
-          guid: activatedRoute.snapshot.params.kubeId
+          guid: activatedRoute.snapshot.params.endpointId
         };
       },
       deps: [

--- a/src/frontend/app/custom/kubernetes/kubernetes-node/kubernetes-node.component.ts
+++ b/src/frontend/app/custom/kubernetes/kubernetes-node/kubernetes-node.component.ts
@@ -19,7 +19,7 @@ import { KubernetesService } from '../services/kubernetes.service';
       provide: BaseKubeGuid,
       useFactory: (activatedRoute: ActivatedRoute) => {
         return {
-          guid: activatedRoute.snapshot.params.kubeId
+          guid: activatedRoute.snapshot.params.endpointId
         };
       },
       deps: [

--- a/src/frontend/app/custom/kubernetes/kubernetes-tab-base/kubernetes-tab-base.component.ts
+++ b/src/frontend/app/custom/kubernetes/kubernetes-tab-base/kubernetes-tab-base.component.ts
@@ -14,7 +14,7 @@ import { KubernetesService } from '../services/kubernetes.service';
       provide: BaseKubeGuid,
       useFactory: (activatedRoute: ActivatedRoute) => {
         return {
-          guid: activatedRoute.snapshot.params.kubeId
+          guid: activatedRoute.snapshot.params.endpointId
         };
       },
       deps: [

--- a/src/frontend/app/custom/kubernetes/kubernetes.routing.ts
+++ b/src/frontend/app/custom/kubernetes/kubernetes.routing.ts
@@ -29,26 +29,26 @@ const kubernetes: Routes = [{
   component: KubernetesComponent
 },
 {
-  path: ':kubeId/apps/:releaseName/pods/:namespace/:podName',
+  path: ':endpointId/apps/:releaseName/pods/:namespace/:podName',
   component: PodMetricsComponent,
 },
 {
-  path: ':kubeId/nodes/:nodeName/pods/:namespace/:podName',
+  path: ':endpointId/nodes/:nodeName/pods/:namespace/:podName',
   component: PodMetricsComponent,
 },
 {
-  path: ':kubeId/pods/:namespace/:podName',
+  path: ':endpointId/pods/:namespace/:podName',
   component: PodMetricsComponent,
 },
 {
-  path: ':kubeId/namespaces/:namespaceName/pods/:podName',
+  path: ':endpointId/namespaces/:namespaceName/pods/:podName',
   component: PodMetricsComponent,
   data: {
     uiFullView: true
   },
 },
 {
-  path: ':kubeId/nodes/:nodeName',
+  path: ':endpointId/nodes/:nodeName',
   component: KubernetesNodeComponent,
   data: {
     uiFullView: true
@@ -74,7 +74,7 @@ const kubernetes: Routes = [{
   ]
 },
 {
-  path: ':kubeId/namespaces/:namespaceName',
+  path: ':endpointId/namespaces/:namespaceName',
   component: KubernetesNamespaceComponent,
   data: {
     uiFullView: true
@@ -92,7 +92,7 @@ const kubernetes: Routes = [{
   ]
 },
 {
-  path: ':kubeId/apps/:releaseName',
+  path: ':endpointId/apps/:releaseName',
   component: HelmReleaseComponent,
   data: {
     uiFullView: true
@@ -114,7 +114,7 @@ const kubernetes: Routes = [{
   ]
 },
 {
-  path: ':kubeId',
+  path: ':endpointId',
   component: KubernetesTabBaseComponent,
   data: {
     uiFullView: true

--- a/src/frontend/app/custom/kubernetes/pod-metrics/pod-metrics.component.ts
+++ b/src/frontend/app/custom/kubernetes/pod-metrics/pod-metrics.component.ts
@@ -35,7 +35,7 @@ import { FetchKubernetesMetricsAction, GetKubernetesPod } from '../store/kuberne
       provide: BaseKubeGuid,
       useFactory: (activatedRoute: ActivatedRoute) => {
         return {
-          guid: activatedRoute.snapshot.params.kubeId
+          guid: activatedRoute.snapshot.params.endpointId
         };
       },
       deps: [

--- a/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
+++ b/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
@@ -276,8 +276,14 @@ export class KubernetesEffects {
               new WrapperRequestActionSuccess(releases, action)
             ];
           }),
-          catchError(err => [
-            new WrapperRequestActionFailed(err.message, action)
+          catchError(error => [
+            new WrapperRequestActionFailed(error.message, action, 'fetch', {
+              endpointIds: [action.kubeGuid],
+              url: error.url || `/pp/${this.proxyAPIVersion}/proxy/api/v1/configmaps`,
+              eventCode: error.status || '500',
+              message: 'Kubernetes API request error',
+              error
+            })
           ])
         );
     })
@@ -328,8 +334,14 @@ export class KubernetesEffects {
         return [
           new WrapperRequestActionSuccess(processesData, action)
         ];
-      }), catchError(err => [
-        new WrapperRequestActionFailed(err.message, action)
+      }), catchError(error => [
+        new WrapperRequestActionFailed(error.message, action, 'fetch', {
+          endpointIds: [action.kubeGuid],
+          url: error.url || url,
+          eventCode: error.status || '500',
+          message: 'Kubernetes API request error',
+          error
+        })
       ]));
   }
 
@@ -356,8 +368,14 @@ export class KubernetesEffects {
         return [
           new WrapperRequestActionSuccess(processesData, action)
         ];
-      }), catchError(err => [
-        new WrapperRequestActionFailed(err.message, action)
+      }), catchError(error => [
+        new WrapperRequestActionFailed(error.message, action, 'fetch', {
+          endpointIds: [action.kubeGuid],
+          url: error.url || url,
+          eventCode: error.status || '500',
+          message: 'Kubernetes API request error',
+          error
+        })
       ]));
   }
 }

--- a/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
+++ b/src/frontend/app/custom/kubernetes/store/kubernetes.effects.ts
@@ -280,7 +280,7 @@ export class KubernetesEffects {
             new WrapperRequestActionFailed(error.message, action, 'fetch', {
               endpointIds: [action.kubeGuid],
               url: error.url || `/pp/${this.proxyAPIVersion}/proxy/api/v1/configmaps`,
-              eventCode: error.status || '500',
+              eventCode: error.status ? error.status + '' : '500',
               message: 'Kubernetes API request error',
               error
             })
@@ -338,7 +338,7 @@ export class KubernetesEffects {
         new WrapperRequestActionFailed(error.message, action, 'fetch', {
           endpointIds: [action.kubeGuid],
           url: error.url || url,
-          eventCode: error.status || '500',
+          eventCode: error.status ? error.status + '' : '500',
           message: 'Kubernetes API request error',
           error
         })
@@ -372,7 +372,7 @@ export class KubernetesEffects {
         new WrapperRequestActionFailed(error.message, action, 'fetch', {
           endpointIds: [action.kubeGuid],
           url: error.url || url,
-          eventCode: error.status || '500',
+          eventCode: error.status ? error.status + '' : '500',
           message: 'Kubernetes API request error',
           error
         })

--- a/src/frontend/app/features/applications/application/application-base.component.ts
+++ b/src/frontend/app/features/applications/application/application-base.component.ts
@@ -48,9 +48,9 @@ export function entityServiceFactory(
 
 export function getGuids(type?: string) {
   return (activatedRoute: ActivatedRoute) => {
-    const { id, cfId } = activatedRoute.snapshot.params;
+    const { id, endpointId } = activatedRoute.snapshot.params;
     if (type) {
-      return cfId;
+      return endpointId;
     }
     return id;
   };

--- a/src/frontend/app/features/applications/applications.routing.ts
+++ b/src/frontend/app/features/applications/applications.routing.ts
@@ -50,7 +50,7 @@ const applicationsRoutes: Routes = [
         }
       },
       {
-        path: ':cfId/:id',
+        path: ':endpointId/:id',
         component: ApplicationBaseComponent,
         children: [
           {

--- a/src/frontend/app/features/cloud-foundry/add-organization/add-organization.component.ts
+++ b/src/frontend/app/features/cloud-foundry/add-organization/add-organization.component.ts
@@ -14,7 +14,7 @@ import { getActiveRouteCfOrgSpaceProvider } from '../cf.helpers';
 export class AddOrganizationComponent {
   cfUrl: string;
   constructor(
-    private activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
+    activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
   ) {
     const cfId = activeRouteCfOrgSpace.cfGuid;
     this.cfUrl = `/cloud-foundry/${cfId}/organizations`;

--- a/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
+++ b/src/frontend/app/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
@@ -39,7 +39,7 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
     private activatedRoute: ActivatedRoute,
     private paginationMonitorFactory: PaginationMonitorFactory,
   ) {
-    this.cfGuid = activatedRoute.snapshot.params.cfId;
+    this.cfGuid = activatedRoute.snapshot.params.endpointId;
   }
 
   ngOnInit() {

--- a/src/frontend/app/features/cloud-foundry/add-space/add-space.component.ts
+++ b/src/frontend/app/features/cloud-foundry/add-space/add-space.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getActiveRouteCfOrgSpaceProvider } from '../cf.helpers';
@@ -13,18 +13,15 @@ import { getActiveRouteCfOrgSpaceProvider } from '../cf.helpers';
   ]
 
 })
-export class AddSpaceComponent implements OnInit {
+export class AddSpaceComponent {
 
   ogrSpacesUrl: string;
   constructor(
-    private activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
+    activeRouteCfOrgSpace: ActiveRouteCfOrgSpace
   ) {
     const cfId = activeRouteCfOrgSpace.cfGuid;
     const orgId = activeRouteCfOrgSpace.orgGuid;
     this.ogrSpacesUrl = `/cloud-foundry/${cfId}/organizations/${orgId}/spaces`;
-  }
-
-  ngOnInit() {
   }
 
 }

--- a/src/frontend/app/features/cloud-foundry/cf.helpers.ts
+++ b/src/frontend/app/features/cloud-foundry/cf.helpers.ts
@@ -174,7 +174,7 @@ export function getIdFromRoute(activatedRoute: ActivatedRoute, id: string) {
 
 export function getActiveRouteCfOrgSpace(activatedRoute: ActivatedRoute) {
   return ({
-    cfGuid: getIdFromRoute(activatedRoute, 'cfId'),
+    cfGuid: getIdFromRoute(activatedRoute, 'endpointId'),
     orgGuid: getIdFromRoute(activatedRoute, 'orgId'),
     spaceGuid: getIdFromRoute(activatedRoute, 'spaceId')
   });
@@ -182,7 +182,7 @@ export function getActiveRouteCfOrgSpace(activatedRoute: ActivatedRoute) {
 
 export function getActiveRouteCfCell(activatedRoute: ActivatedRoute) {
   return ({
-    cfGuid: getIdFromRoute(activatedRoute, 'cfId'),
+    cfGuid: getIdFromRoute(activatedRoute, 'endpointId'),
     cellId: getIdFromRoute(activatedRoute, 'cellId'),
   });
 }

--- a/src/frontend/app/features/cloud-foundry/cloud-foundry-base/cloud-foundry-base.component.ts
+++ b/src/frontend/app/features/cloud-foundry/cloud-foundry-base/cloud-foundry-base.component.ts
@@ -7,7 +7,7 @@ import { CloudFoundryEndpointService } from '../services/cloud-foundry-endpoint.
 
 function getCfIdFromUrl(activatedRoute: ActivatedRoute) {
   return {
-    guid: activatedRoute.snapshot.params.cfId
+    guid: activatedRoute.snapshot.params.endpointId
   };
 }
 @Component({

--- a/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
+++ b/src/frontend/app/features/cloud-foundry/cloud-foundry.routing.ts
@@ -94,7 +94,7 @@ const cloudFoundry: Routes = [{
   component: CloudFoundryComponent
 },
 {
-  path: ':cfId',
+  path: ':endpointId',
   children: [
     {
       path: 'add-org',

--- a/src/frontend/app/features/service-catalog/service-catalog.routing.ts
+++ b/src/frontend/app/features/service-catalog/service-catalog.routing.ts
@@ -17,11 +17,11 @@ const serviceCatalog: Routes = [
     component: ServiceCatalogPageComponent,
   },
   {
-    path: ':cfId/:serviceId/create',
+    path: ':endpointId/:serviceId/create',
     component: AddServiceInstanceComponent,
   },
   {
-    path: ':cfId/:serviceId',
+    path: ':endpointId/:serviceId',
     component: ServiceBaseComponent,
     children: [
       {

--- a/src/frontend/app/features/service-catalog/services-helper.ts
+++ b/src/frontend/app/features/service-catalog/services-helper.ts
@@ -56,23 +56,23 @@ export const getServiceJsonParams = (params: any): {} => {
 
 export const isMarketplaceMode = (activatedRoute: ActivatedRoute) => {
   const serviceId = getIdFromRoute(activatedRoute, 'serviceId');
-  const cfId = getIdFromRoute(activatedRoute, 'cfId');
+  const cfId = getIdFromRoute(activatedRoute, 'endpointId');
   return !!serviceId && !!cfId;
 };
 
 export const isAppServicesMode = (activatedRoute: ActivatedRoute) => {
   const id = getIdFromRoute(activatedRoute, 'id');
-  const cfId = getIdFromRoute(activatedRoute, 'cfId');
+  const cfId = getIdFromRoute(activatedRoute, 'endpointId');
   return !!id && !!cfId;
 };
 export const isServicesWallMode = (activatedRoute: ActivatedRoute) => {
-  const cfId = getIdFromRoute(activatedRoute, 'cfId');
+  const cfId = getIdFromRoute(activatedRoute, 'endpointId');
   return !cfId;
 };
 
 export const isEditServiceInstanceMode = (activatedRoute: ActivatedRoute) => {
   const serviceInstanceId = getIdFromRoute(activatedRoute, 'serviceInstanceId');
-  const cfId = getIdFromRoute(activatedRoute, 'cfId');
+  const cfId = getIdFromRoute(activatedRoute, 'endpointId');
   return !!cfId && !!serviceInstanceId;
 };
 
@@ -90,23 +90,23 @@ export const getServicePlans = (
   cfGuid: string,
   store: Store<AppState>,
   paginationMonitorFactory: PaginationMonitorFactory
-): Observable<APIResource<IServicePlan>[]>  => {
+): Observable<APIResource<IServicePlan>[]> => {
   return service$.pipe(
     filter(p => !!p),
     switchMap(service => {
-    if (service.entity.service_plans && service.entity.service_plans.length > 0) {
-      return observableOf(service.entity.service_plans);
-    } else {
-      const guid = service.metadata.guid;
-      const paginationKey = createEntityRelationPaginationKey(servicePlanSchemaKey, guid);
-      const getServicePlansAction = new GetServicePlansForService(guid, cfGuid, paginationKey);
-      // Could be a space-scoped service, make a request to fetch the plan
-      return getPaginationObservables<APIResource<IServicePlan>>({
-        store: store,
-        action: getServicePlansAction,
-        paginationMonitor: paginationMonitorFactory.create(getServicePlansAction.paginationKey, entityFactory(servicePlanSchemaKey))
-      }, true)
-        .entities$.pipe(share(), first());
-    }
-  }));
+      if (service.entity.service_plans && service.entity.service_plans.length > 0) {
+        return observableOf(service.entity.service_plans);
+      } else {
+        const guid = service.metadata.guid;
+        const paginationKey = createEntityRelationPaginationKey(servicePlanSchemaKey, guid);
+        const getServicePlansAction = new GetServicePlansForService(guid, cfGuid, paginationKey);
+        // Could be a space-scoped service, make a request to fetch the plan
+        return getPaginationObservables<APIResource<IServicePlan>>({
+          store: store,
+          action: getServicePlansAction,
+          paginationMonitor: paginationMonitorFactory.create(getServicePlansAction.paginationKey, entityFactory(servicePlanSchemaKey))
+        }, true)
+          .entities$.pipe(share(), first());
+      }
+    }));
 };

--- a/src/frontend/app/features/service-catalog/services.service.ts
+++ b/src/frontend/app/features/service-catalog/services.service.ts
@@ -72,7 +72,7 @@ export class ServicesService {
 
   ) {
 
-    this.cfGuid = getIdFromRoute(activatedRoute, 'cfId');
+    this.cfGuid = getIdFromRoute(activatedRoute, 'endpointId');
     this.serviceGuid = getIdFromRoute(activatedRoute, 'serviceId');
 
     this.serviceEntityService = this.entityServiceFactory.create(

--- a/src/frontend/app/features/services/detach-service-instance/detach-service-instance.component.ts
+++ b/src/frontend/app/features/services/detach-service-instance/detach-service-instance.component.ts
@@ -60,7 +60,7 @@ export class DetachServiceInstanceComponent {
     private activatedRoute: ActivatedRoute,
     private entityServiceFactory: EntityServiceFactory
   ) {
-    this.cfGuid = activatedRoute.snapshot.params.cfId;
+    this.cfGuid = activatedRoute.snapshot.params.endpointId;
     const serviceInstanceId = activatedRoute.snapshot.params.serviceInstanceId;
 
     const serviceBindingEntityService = this.entityServiceFactory.create<APIResource<IServiceInstance>>(

--- a/src/frontend/app/features/services/services.routing.ts
+++ b/src/frontend/app/features/services/services.routing.ts
@@ -17,11 +17,11 @@ const services: Routes = [
     component: AddServiceInstanceComponent
   },
   {
-    path: ':cfId/:serviceInstanceId/edit',
+    path: ':endpointId/:serviceInstanceId/edit',
     component: AddServiceInstanceComponent
   },
   {
-    path: ':cfId/:serviceInstanceId/detach',
+    path: ':endpointId/:serviceInstanceId/detach',
     component: DetachServiceInstanceComponent
   }
 ];

--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -164,7 +164,7 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
   }
 
   private configureForEditServiceInstanceMode() {
-    const { cfId, serviceInstanceId } = this.activatedRoute.snapshot.params;
+    const { endpointId, serviceInstanceId } = this.activatedRoute.snapshot.params;
     const entityService = this.getServiceInstanceEntityService(serviceInstanceId, cfId);
     return entityService.waitForEntity$.pipe(
       filter(p => !!p),
@@ -228,7 +228,7 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
   isSpaceScoped = () => this.modeService.spaceScopedDetails.isSpaceScoped;
 
   private initialiseForMarketplaceMode(): Observable<boolean> {
-    const { cfId, serviceId } = this.activatedRoute.snapshot.params;
+    const { endpointId, serviceId } = this.activatedRoute.snapshot.params;
     this.csiGuidsService.cfGuid = cfId;
     this.csiGuidsService.serviceGuid = serviceId;
     this.cSIHelperService = this.cSIHelperServiceFactory.create(cfId, serviceId);

--- a/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -132,7 +132,7 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
 
   private getIdsFromRoute() {
     const serviceId = getIdFromRoute(this.activatedRoute, 'serviceId');
-    const cfId = getIdFromRoute(this.activatedRoute, 'cfId');
+    const cfId = getIdFromRoute(this.activatedRoute, 'endpointId');
     const appId = getIdFromRoute(this.activatedRoute, 'id');
     return { serviceId, cfId, appId };
   }
@@ -140,7 +140,7 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
   private setupForAppServiceMode() {
 
     const appId = getIdFromRoute(this.activatedRoute, 'id');
-    const cfId = getIdFromRoute(this.activatedRoute, 'cfId');
+    const cfId = getIdFromRoute(this.activatedRoute, 'endpointId');
     this.appId = appId;
     this.bindAppStepperText = 'Binding Params (Optional)';
     const entityService = this.entityServiceFactory.create<APIResource<IApp>>(
@@ -165,16 +165,16 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
 
   private configureForEditServiceInstanceMode() {
     const { endpointId, serviceInstanceId } = this.activatedRoute.snapshot.params;
-    const entityService = this.getServiceInstanceEntityService(serviceInstanceId, cfId);
+    const entityService = this.getServiceInstanceEntityService(serviceInstanceId, endpointId);
     return entityService.waitForEntity$.pipe(
       filter(p => !!p),
       tap(serviceInstance => {
         const serviceInstanceEntity = serviceInstance.entity.entity;
-        this.csiGuidsService.cfGuid = cfId;
+        this.csiGuidsService.cfGuid = endpointId;
         this.title$ = observableOf(`Edit Service Instance: ${serviceInstanceEntity.name}`);
         const serviceGuid = serviceInstance.entity.entity.service_guid;
         this.csiGuidsService.serviceGuid = serviceGuid;
-        this.cSIHelperService = this.cSIHelperServiceFactory.create(cfId, serviceGuid);
+        this.cSIHelperService = this.cSIHelperServiceFactory.create(endpointId, serviceGuid);
         this.store.dispatch(new SetCreateServiceInstanceServiceGuid(serviceGuid));
         this.store.dispatch(new SetServiceInstanceGuid(serviceInstance.entity.metadata.guid));
         this.store.dispatch(new SetCreateServiceInstance(
@@ -184,12 +184,12 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
           ''
         ));
         this.store.dispatch(new SetCreateServiceInstanceServicePlan(serviceInstanceEntity.service_plan_guid));
-        const spaceEntityService = this.getSpaceEntityService(serviceInstanceEntity.space_guid, cfId);
+        const spaceEntityService = this.getSpaceEntityService(serviceInstanceEntity.space_guid, endpointId);
         spaceEntityService.waitForEntity$.pipe(
           filter(p => !!p),
           tap(spaceEntity => {
             this.store.dispatch(new SetCreateServiceInstanceCFDetails(
-              cfId,
+              endpointId,
               spaceEntity.entity.entity.organization_guid,
               spaceEntity.entity.metadata.guid)
             );
@@ -229,10 +229,10 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
 
   private initialiseForMarketplaceMode(): Observable<boolean> {
     const { endpointId, serviceId } = this.activatedRoute.snapshot.params;
-    this.csiGuidsService.cfGuid = cfId;
+    this.csiGuidsService.cfGuid = endpointId;
     this.csiGuidsService.serviceGuid = serviceId;
-    this.cSIHelperService = this.cSIHelperServiceFactory.create(cfId, serviceId);
-    const cfDetails = new SetCreateServiceInstanceCFDetails(cfId);
+    this.cSIHelperService = this.cSIHelperServiceFactory.create(endpointId, serviceId);
+    const cfDetails = new SetCreateServiceInstanceCFDetails(endpointId);
     if (this.modeService.spaceScopedDetails.isSpaceScoped) {
       cfDetails.spaceGuid = this.modeService.spaceScopedDetails.spaceGuid;
       cfDetails.orgGuid = this.modeService.spaceScopedDetails.orgGuid;
@@ -244,7 +244,7 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
     return this.cfOrgSpaceService.cf.list$.pipe(
       filter(p => !!p),
       first(),
-      tap(e => this.cfOrgSpaceService.cf.select.next(cfId)),
+      tap(e => this.cfOrgSpaceService.cf.select.next(endpointId)),
       map(o => false),
     );
   }

--- a/src/frontend/app/shared/components/add-service-instance/csi-mode.service.ts
+++ b/src/frontend/app/shared/components/add-service-instance/csi-mode.service.ts
@@ -40,7 +40,7 @@ export class CsiModeService {
   ) {
     const serviceId = getIdFromRoute(activatedRoute, 'serviceId');
     const serviceInstanceId = getIdFromRoute(activatedRoute, 'serviceInstanceId');
-    const cfId = getIdFromRoute(activatedRoute, 'cfId');
+    const cfId = getIdFromRoute(activatedRoute, 'endpointId');
     const id = getIdFromRoute(activatedRoute, 'id');
 
     if (!!serviceId && !!cfId) {

--- a/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/app/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -92,7 +92,7 @@ export class SelectPlanStepComponent implements OnDestroy {
     });
 
     if (modeService.isMarketplaceMode()) {
-      this.store.dispatch(new SetCreateServiceInstanceCFDetails(activatedRoute.snapshot.params.cfId));
+      this.store.dispatch(new SetCreateServiceInstanceCFDetails(activatedRoute.snapshot.params.endpointId));
     }
 
     this.servicePlans$ = this.store.select(selectCreateServiceInstance).pipe(

--- a/src/frontend/app/shared/components/list/list-types/detach-apps/detach-apps-list-config.service.ts
+++ b/src/frontend/app/shared/components/list/list-types/detach-apps/detach-apps-list-config.service.ts
@@ -48,8 +48,8 @@ export class DetachAppsListConfigService implements IListConfig<APIResource> {
 
   constructor(private store: Store<AppState>, private activatedRoute: ActivatedRoute, private datePipe: DatePipe) {
 
-    const { serviceInstanceId, cfId } = activatedRoute.snapshot.params;
-    this.dataSource = new DetachAppsDataSource(cfId, serviceInstanceId, this.store, this);
+    const { serviceInstanceId, endpointId } = activatedRoute.snapshot.params;
+    this.dataSource = new DetachAppsDataSource(endpointId, serviceInstanceId, this.store, this);
   }
 
   getColumns = () => this.columns;

--- a/src/frontend/app/shared/components/page-header/page-header-events/page-header-events.component.ts
+++ b/src/frontend/app/shared/components/page-header/page-header-events/page-header-events.component.ts
@@ -1,18 +1,18 @@
 
-import { of as observableOf, Observable } from 'rxjs';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { withLatestFrom, map, filter, distinctUntilChanged } from 'rxjs/operators';
-
+import { Store } from '@ngrx/store';
+import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
+import { ToggleHeaderEvent } from '../../../../store/actions/dashboard-actions';
+import { AppState } from '../../../../store/app-state';
 import { endpointSchemaKey, entityFactory } from '../../../../store/helpers/entity-factory';
 import { CloudFoundryService } from '../../../data-services/cloud-foundry.service';
 import { InternalEventMonitorFactory } from '../../../monitors/internal-event-monitor.factory';
-import { AppState } from '../../../../store/app-state';
-import { Store } from '@ngrx/store';
-import { DashboardState } from '../../../../store/reducers/dashboard-reducer';
-import { ToggleHeaderEvent } from '../../../../store/actions/dashboard-actions';
 import { PaginationMonitor } from '../../../monitors/pagination-monitor';
+import { EndpointModel } from '../../../../store/types/endpoint.types';
+
 
 @Component({
   selector: 'app-page-header-events',
@@ -61,11 +61,15 @@ export class PageHeaderEventsComponent implements OnInit {
       this.endpointIds$ = observableOf([this.activatedRoute.snapshot.params.endpointId]);
     }
     if (this.endpointIds$) {
-      const endpointMonitor = new PaginationMonitor(this.store, CloudFoundryService.EndpointList, entityFactory(endpointSchemaKey));
+      const endpointMonitor = new PaginationMonitor<EndpointModel>(
+        this.store, CloudFoundryService.EndpointList, entityFactory(endpointSchemaKey)
+      );
       const cfEndpointEventMonitor = this.internalEventMonitorFactory.getMonitor(endpointSchemaKey, this.endpointIds$);
-      this.errorMessage$ = cfEndpointEventMonitor.hasErroredOverTime().pipe(
-        filter(errors => !!errors && !!errors.length),
-        withLatestFrom(endpointMonitor.currentPage$),
+      this.errorMessage$ = combineLatest(
+        cfEndpointEventMonitor.hasErroredOverTime(),
+        endpointMonitor.currentPage$
+      ).pipe(
+        filter(([errors]) => !!errors && !!errors.length),
         map(([errors, endpoints]) => {
           const endpointString = errors.map(
             id => endpoints.find(endpoint => endpoint.guid === id)

--- a/src/frontend/app/store/actions/internal-events.actions.ts
+++ b/src/frontend/app/store/actions/internal-events.actions.ts
@@ -25,12 +25,12 @@ export class SendClearEventAction implements Action {
     public eventSubjectId: string,
     public params: {
       timestamp?: number,
-      eventCode?: string
+      eventCode?: string,
+      clean: boolean
     }
-
   ) {
-    const { timestamp, eventCode } = params;
-    if (!timestamp && !eventCode) {
+    const { timestamp, eventCode, clean } = params;
+    if (!timestamp && !eventCode && !clean) {
       throw new Error('Either a timestamp or event code is needed to clear events');
     }
   }

--- a/src/frontend/app/store/effects/action-history.effects.ts
+++ b/src/frontend/app/store/effects/action-history.effects.ts
@@ -1,5 +1,5 @@
 
-import {take, map} from 'rxjs/operators';
+import { take, map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { AppState } from '../app-state';
 import { Injectable } from '@angular/core';

--- a/src/frontend/app/store/effects/api.effects.ts
+++ b/src/frontend/app/store/effects/api.effects.ts
@@ -230,11 +230,18 @@ export class APIEffect {
               ),
             );
           }
+          const { error, errorCode, guid, url, errorResponse } = errorsCheck[0];
           this.store.dispatch(
             new WrapperRequestActionFailed(
               errorMessage,
-              { ...actionClone, endpointGuid: errorsCheck[0].guid },
-              requestType,
+              { ...actionClone, endpointGuid: guid },
+              requestType, {
+                endpointIds: [guid],
+                url,
+                eventCode: errorCode ? errorCode + '' : '500',
+                message: errorResponse ? errorResponse.description : 'Jetstream CF API request error',
+                error
+              }
             ),
           );
           return [];

--- a/src/frontend/app/store/effects/cloud-foundry.effects.ts
+++ b/src/frontend/app/store/effects/cloud-foundry.effects.ts
@@ -58,7 +58,7 @@ export class CloudFoundryEffects {
             new WrapperRequestActionFailed(error.message, apiAction, actionType, {
               endpointIds: [action.cfGuid],
               url: error.url || url,
-              eventCode: error.status || '500',
+              eventCode: error.status ? error.status + '' : '500',
               message: 'Cloud Foundry Info request error',
               error
             })

--- a/src/frontend/app/store/effects/cloud-foundry.effects.ts
+++ b/src/frontend/app/store/effects/cloud-foundry.effects.ts
@@ -33,8 +33,9 @@ export class CloudFoundryEffects {
       const requestArgs = {
         headers: headers
       };
+      const url = `/pp/${this.proxyAPIVersion}/proxy/v2/info`;
       return this.http
-        .get(`/pp/${this.proxyAPIVersion}/proxy/v2/info`, requestArgs)
+        .get(url, requestArgs)
         .pipe(
           mergeMap(response => {
             const info = response.json();
@@ -53,8 +54,14 @@ export class CloudFoundryEffects {
               new WrapperRequestActionSuccess(mappedData, apiAction, actionType)
             ];
           }),
-          catchError(err => [
-            new WrapperRequestActionFailed(err.message, apiAction, actionType)
+          catchError(error => [
+            new WrapperRequestActionFailed(error.message, apiAction, actionType, {
+              endpointIds: [action.cfGuid],
+              url: error.url || url,
+              eventCode: error.status || '500',
+              message: 'Cloud Foundry Info request error',
+              error
+            })
           ])
         );
     })

--- a/src/frontend/app/store/effects/endpoint-api-errors.effects.ts
+++ b/src/frontend/app/store/effects/endpoint-api-errors.effects.ts
@@ -1,0 +1,47 @@
+
+
+// RequestTypes.FAILED
+
+
+import { take, map } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
+import { AppState } from '../app-state';
+import { Injectable } from '@angular/core';
+import { Effect, Actions } from '@ngrx/effects';
+import { RequestTypes } from '../actions/request.actions';
+import { WrapperRequestActionFailed } from '../types/request.types';
+import { endpointSchemaKey } from '../helpers/entity-factory';
+import { SendEventAction } from '../actions/internal-events.actions';
+import { InternalEventSeverity } from '../types/internal-events.types';
+
+
+@Injectable()
+export class EndpointApiError {
+
+  constructor(
+    private actions$: Actions,
+    private store: Store<AppState>,
+  ) { }
+
+  @Effect({ dispatch: false }) endpointApiError$ = this.actions$.ofType<WrapperRequestActionFailed>(RequestTypes.FAILED).pipe(
+    map(action => {
+      const internalEndpointError = action.internalEndpointError;
+      if (internalEndpointError) {
+        const { eventCode, message, error, url } = internalEndpointError;
+        internalEndpointError.endpointIds.forEach(endpoint =>
+          this.store.dispatch(
+            new SendEventAction(endpointSchemaKey, endpoint, {
+              eventCode,
+              severity: InternalEventSeverity.ERROR,
+              message,
+              metadata: {
+                error,
+                url,
+              },
+            }),
+          ),
+        );
+      }
+    }));
+}
+

--- a/src/frontend/app/store/effects/endpoint.effects.ts
+++ b/src/frontend/app/store/effects/endpoint.effects.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular
 import { Injectable } from '@angular/core';
 import { Actions, Effect } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { catchError, mergeMap } from 'rxjs/operators';
+import { catchError, mergeMap, tap } from 'rxjs/operators';
 
 import { BrowserStandardEncoder } from '../../helper';
 import {
@@ -38,6 +38,8 @@ import {
   WrapperRequestActionFailed,
   WrapperRequestActionSuccess,
 } from '../types/request.types';
+import { SendClearEventAction } from '../actions/internal-events.actions';
+import { endpointSchemaKey } from '../helpers/entity-factory';
 
 
 @Injectable()
@@ -139,6 +141,8 @@ export class EndpointsEffect {
         null,
         [DISCONNECT_ENDPOINTS_SUCCESS, DISCONNECT_ENDPOINTS_FAILED],
         action.endpointType
+      ).pipe(
+        tap(() => this.clearEndpointInternalEvents(action.guid))
       );
     }));
 
@@ -159,6 +163,8 @@ export class EndpointsEffect {
         'delete',
         [UNREGISTER_ENDPOINTS_SUCCESS, UNREGISTER_ENDPOINTS_FAILED],
         action.endpointType
+      ).pipe(
+        tap(() => this.clearEndpointInternalEvents(action.guid))
       );
     }));
 
@@ -230,20 +236,22 @@ export class EndpointsEffect {
     return this.http.post(url, body || {}, {
       headers,
       params
-    }).pipe(mergeMap((endpoint: EndpointModel) => {
-      const actions = [];
-      if (actionStrings[0]) {
-        actions.push(new EndpointActionComplete(actionStrings[0], apiAction.guid, endpointType, endpoint));
+    }).pipe(
+      mergeMap((endpoint: EndpointModel) => {
+        const actions = [];
+        if (actionStrings[0]) {
+          actions.push(new EndpointActionComplete(actionStrings[0], apiAction.guid, endpointType, endpoint));
+        }
+        if (apiActionType === 'delete') {
+          actions.push(new ClearPaginationOfEntity(apiAction.entityKey, apiAction.guid));
+        }
+        if (apiActionType === 'create') {
+          actions.push(new GetSystemInfo());
+        }
+        actions.push(new WrapperRequestActionSuccess(null, apiAction, apiActionType));
+        return actions;
       }
-      if (apiActionType === 'delete') {
-        actions.push(new ClearPaginationOfEntity(apiAction.entityKey, apiAction.guid));
-      }
-      if (apiActionType === 'create') {
-        actions.push(new GetSystemInfo());
-      }
-      actions.push(new WrapperRequestActionSuccess(null, apiAction, apiActionType));
-      return actions;
-    }),
+      ),
       catchError(e => {
         const actions = [];
         if (actionStrings[1]) {
@@ -252,6 +260,18 @@ export class EndpointsEffect {
         const errorMessage = errorMessageHandler ? errorMessageHandler(e) : 'Could not perform action';
         actions.push(new WrapperRequestActionFailed(errorMessage, apiAction, apiActionType));
         return actions;
-      }), );
+      }));
+  }
+
+  private clearEndpointInternalEvents(guid: string) {
+    this.store.dispatch(
+      new SendClearEventAction(
+        endpointSchemaKey,
+        guid,
+        {
+          clean: true
+        }
+      )
+    );
   }
 }

--- a/src/frontend/app/store/effects/metrics.effects.ts
+++ b/src/frontend/app/store/effects/metrics.effects.ts
@@ -66,7 +66,7 @@ export class MetricsEffect {
             'fetch', {
               endpointIds: [action.endpointGuid],
               url: errObservable.url || fullUrl,
-              eventCode: errObservable.status || '500',
+              eventCode: errObservable.status ? errObservable.status + '' : '500',
               message: 'Metric request error',
             }
           )

--- a/src/frontend/app/store/effects/metrics.effects.ts
+++ b/src/frontend/app/store/effects/metrics.effects.ts
@@ -63,7 +63,12 @@ export class MetricsEffect {
           new WrapperRequestActionFailed(
             errObservable.message,
             action,
-            'fetch'
+            'fetch', {
+              endpointIds: [action.endpointGuid],
+              url: errObservable.url || fullUrl,
+              eventCode: errObservable.status || '500',
+              message: 'Metric request error',
+            }
           )
         ];
       }));

--- a/src/frontend/app/store/reducers/api-request-reducer/request-helpers.ts
+++ b/src/frontend/app/store/reducers/api-request-reducer/request-helpers.ts
@@ -12,7 +12,8 @@ import {
   StartRequestAction,
   APISuccessOrFailedAction,
   WrapperRequestActionSuccess,
-  WrapperRequestActionFailed
+  WrapperRequestActionFailed,
+  InternalEndpointError
 } from '../../types/request.types';
 import { defaultDeletingActionState, getDefaultActionState, getDefaultRequestState, RequestInfoState, rootUpdatingKey } from './types';
 import { Store } from '@ngrx/store';
@@ -172,11 +173,13 @@ export function failApiRequest(
   apiAction: ICFAction | PaginatedAction,
   error,
   requestType: ApiRequestTypes = 'fetch',
+  internalEndpointError?: InternalEndpointError
 ) {
   const actions = getFailApiRequestActions(
     apiAction,
     error,
-    requestType
+    requestType,
+    internalEndpointError
   );
   store.dispatch(actions[0]);
   store.dispatch(actions[1]);
@@ -186,13 +189,15 @@ export function getFailApiRequestActions(
   apiAction: ICFAction | PaginatedAction,
   error,
   requestType: ApiRequestTypes = 'fetch',
+  internalEndpointError?: InternalEndpointError
 ) {
   return [
     new APISuccessOrFailedAction(apiAction.actions[2], apiAction, error.message),
     new WrapperRequestActionFailed(
       error.message,
       apiAction,
-      requestType
+      requestType,
+      internalEndpointError
     )
   ];
 }

--- a/src/frontend/app/store/reducers/internal-events.reducer.ts
+++ b/src/frontend/app/store/reducers/internal-events.reducer.ts
@@ -28,7 +28,7 @@ export function internalEventReducer(state: InternalEventsState = defaultState, 
       ]);
     }
     case CLEAR_EVENTS: {
-      return this.clearEvents(state, action);
+      return clearEvents(state, action as SendClearEventAction);
     }
   }
   return state;
@@ -54,7 +54,7 @@ function setSubjectEvents(state: InternalEventsState, eventSubjectId: string, ev
 function clearEvents(state: InternalEventsState, clearAction: SendClearEventAction) {
   const { eventSubjectId, eventType, params } = clearAction;
   const events = getEvents(state, eventSubjectId, eventType);
-  const filteredEvents = events.filter((event: InternalEventState) => {
+  const filteredEvents = clearAction.params.clean ? [] : events.filter((event: InternalEventState) => {
     if (params.timestamp) {
       return params.timestamp < event.timestamp;
     }

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-type.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination-reducer-clear-pagination-type.ts
@@ -1,3 +1,13 @@
+import {
+  kubernetesSchemaKey,
+  kubernetesNodesSchemaKey,
+  kubernetesPodsSchemaKey,
+  kubernetesNamespacesSchemaKey,
+  kubernetesServicesSchemaKey,
+  kubernetesStatefulSetsSchemaKey,
+  kubernetesDeploymentsSchemaKey,
+  kubernetesAppsSchemaKey
+} from './../../helpers/entity-factory';
 import { EndpointAction } from '../../actions/endpoint.actions';
 import {
   applicationSchemaKey,
@@ -9,29 +19,55 @@ import {
 } from '../../helpers/entity-factory';
 import { PaginationState } from '../../types/pagination.types';
 
-export function paginationClearType(state: PaginationState, entityKey, defaultPaginationEntityState) {
-  if (state[entityKey]) {
-    const clearState = { ...state };
-    const entityState = clearState[entityKey];
-    const newObject = {};
-    Object.keys(entityState).forEach(key => {
-      newObject[key] = defaultPaginationEntityState;
-    });
-    clearState[entityKey] = newObject;
-    return clearState;
-  }
-  return state;
+export function paginationClearAllTypes(state: PaginationState, entityKeys: string[], defaultPaginationEntityState) {
+  return entityKeys.reduce((prevState, entityKey) => {
+    if (prevState[entityKey]) {
+      const entityState = state[entityKey];
+      const clearedEntity = Object.keys(entityState).reduce((prevEntityState, key) => {
+        return {
+          ...prevEntityState,
+          [key]: defaultPaginationEntityState
+        };
+      }, entityState);
+      return {
+        ...prevState,
+        [entityKey]: clearedEntity
+      };
+    }
+    return prevState;
+  }, state);
 }
 
 export function clearEndpointEntities(state: PaginationState, action: EndpointAction, defaultPaginationEntityState) {
   if (action.endpointType === 'cf') {
-    let newState = paginationClearType(state, applicationSchemaKey, defaultPaginationEntityState);
-    newState = paginationClearType(newState, spaceSchemaKey, defaultPaginationEntityState);
-    newState = paginationClearType(newState, organizationSchemaKey, defaultPaginationEntityState);
-    newState = paginationClearType(newState, serviceSchemaKey, defaultPaginationEntityState);
-    newState = paginationClearType(newState, cfUserSchemaKey, defaultPaginationEntityState);
-    newState = paginationClearType(newState, serviceInstancesSchemaKey, defaultPaginationEntityState);
-    return newState;
+    return paginationClearAllTypes(
+      state,
+      [
+        applicationSchemaKey,
+        spaceSchemaKey,
+        organizationSchemaKey,
+        serviceSchemaKey,
+        cfUserSchemaKey,
+        serviceInstancesSchemaKey,
+      ],
+      defaultPaginationEntityState
+    );
+  }
+  if (action.endpointType === 'k8s') {
+    return paginationClearAllTypes(
+      state,
+      [
+        kubernetesSchemaKey,
+        kubernetesNodesSchemaKey,
+        kubernetesPodsSchemaKey,
+        kubernetesNamespacesSchemaKey,
+        kubernetesServicesSchemaKey,
+        kubernetesStatefulSetsSchemaKey,
+        kubernetesDeploymentsSchemaKey,
+        kubernetesAppsSchemaKey,
+      ],
+      defaultPaginationEntityState
+    );
   }
   return state;
 }

--- a/src/frontend/app/store/reducers/pagination-reducer/pagination.reducer.ts
+++ b/src/frontend/app/store/reducers/pagination-reducer/pagination.reducer.ts
@@ -27,7 +27,7 @@ import { PaginationEntityState, PaginationState } from '../../types/pagination.t
 import { paginationAddParams } from './pagination-reducer-add-params';
 import { paginationClearPages } from './pagination-reducer-clear-pages';
 import { paginationClearOfEntity } from './pagination-reducer-clear-pagination-of-entity';
-import { clearEndpointEntities, paginationClearType } from './pagination-reducer-clear-pagination-type';
+import { clearEndpointEntities, paginationClearAllTypes } from './pagination-reducer-clear-pagination-type';
 import { createNewPaginationSection } from './pagination-reducer-create-pagination';
 import { paginationRemoveParams } from './pagination-reducer-remove-params';
 import { paginationResetPagination } from './pagination-reducer-reset-pagination';
@@ -139,7 +139,7 @@ function paginate(action, state, updatePagination) {
 
   if (action.type === CLEAR_PAGINATION_OF_TYPE) {
     const clearEntityType = action.entityKey || 'application';
-    return paginationClearType(state, clearEntityType, getDefaultPaginationEntityState());
+    return paginationClearAllTypes(state, [clearEntityType], getDefaultPaginationEntityState());
   }
 
   if (action.type === CLEAR_PAGINATION_OF_ENTITY) {

--- a/src/frontend/app/store/store.module.ts
+++ b/src/frontend/app/store/store.module.ts
@@ -30,6 +30,7 @@ import { UsersRolesEffects } from './effects/users-roles.effects';
 import { UsersEffects } from './effects/users.effects';
 import { AppReducersModule } from './reducers.module';
 import { KubernetesEffects } from '../custom/kubernetes/store/kubernetes.effects';
+import { EndpointApiError } from './effects/endpoint-api-errors.effects';
 
 @NgModule({
   imports: [
@@ -38,6 +39,7 @@ import { KubernetesEffects } from '../custom/kubernetes/store/kubernetes.effects
     HttpClientModule,
     EffectsModule.forRoot([
       APIEffect,
+      EndpointApiError,
       AuthEffect,
       UAASetupEffect,
       EndpointsEffect,

--- a/src/frontend/app/store/types/request.types.ts
+++ b/src/frontend/app/store/types/request.types.ts
@@ -136,12 +136,19 @@ export class WrapperRequestActionSuccess extends RequestSuccessAction implements
     super();
   }
 }
-
+export interface InternalEndpointError {
+  endpointIds: string[];
+  eventCode?: string;
+  message?: string;
+  url: string;
+  error?;
+}
 export class WrapperRequestActionFailed extends RequestFailedAction implements IFailedRequestAction {
   constructor(
     public message: string,
     public apiAction: IRequestAction | PaginatedAction,
-    public requestType: ApiRequestTypes = 'fetch'
+    public requestType: ApiRequestTypes = 'fetch',
+    public internalEndpointError?: InternalEndpointError
   ) {
     super();
   }

--- a/src/test-e2e/cloud-foundry/cf-level/cf-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/cf-level/cf-users-list-e2e.spec.ts
@@ -2,6 +2,7 @@ import { protractor } from 'protractor';
 
 import { e2e } from '../../e2e';
 import { E2EHelpers } from '../../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../../helpers/extend-test-helpers';
 import { CFUsersListComponent } from '../../po/cf-users-list.po';
 import { setUpTestOrgSpaceE2eTest } from '../users-list-e2e.helper';
 import { CfTopLevelPage } from './cf-top-level-page.po';
@@ -29,6 +30,9 @@ describe('Cf Users List -', () => {
       return cfPage.goToUsersTab();
     });
   });
+
+  const timeout = 60000;
+  extendE2ETestTime(timeout);
 
   it('Correct role pills shown, pills removed successfully', () => {
     expect(cfPage.isActivePageOrChildPage()).toBeTruthy();
@@ -68,10 +72,8 @@ describe('Cf Users List -', () => {
     orgUserChip.check(true);
     orgUserChip.remove();
 
-  });
+  }, timeout);
 
 
-  afterAll(() => {
-    return cfHelper.deleteOrgIfExisting(cfGuid, orgName);
-  });
+  afterAll(() => cfHelper.deleteOrgIfExisting(cfGuid, orgName));
 });

--- a/src/test-e2e/cloud-foundry/manage-users-stepper-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/manage-users-stepper-e2e.spec.ts
@@ -1,12 +1,14 @@
-import { protractor, by, element, browser } from 'protractor';
+import { browser, by, element, protractor } from 'protractor';
+
 import { e2e } from '../e2e';
+import { CFHelpers } from '../helpers/cf-helpers';
 import { E2EHelpers } from '../helpers/e2e-helpers';
-import { ManagerUsersPage } from './manage-users-page.po';
-import { setUpTestOrgSpaceE2eTest } from './users-list-e2e.helper';
-import { CfTopLevelPage } from './cf-level/cf-top-level-page.po';
+import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { CFUsersListComponent } from '../po/cf-users-list.po';
 import { CheckboxComponent } from '../po/checkbox.po';
-import { CFHelpers } from '../helpers/cf-helpers';
+import { CfTopLevelPage } from './cf-level/cf-top-level-page.po';
+import { ManagerUsersPage } from './manage-users-page.po';
+import { setUpTestOrgSpaceE2eTest } from './users-list-e2e.helper';
 
 describe('Manage Users Stepper', () => {
 
@@ -17,17 +19,6 @@ describe('Manage Users Stepper', () => {
   const userName = e2e.secrets.getDefaultCFEndpoint().creds.nonAdmin.username;
 
   let manageUsersPage: ManagerUsersPage, cfHelper: CFHelpers, cfGuid, userGuid;
-
-  let originalTimeout = 40000;
-
-  beforeEach(function() {
-    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 90000;
-  });
-
-  afterEach(function() {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-  });
 
   beforeAll(() => {
     setUpTestOrgSpaceE2eTest(orgName, spaceName, userName, true).then(res => {
@@ -45,6 +36,9 @@ describe('Manage Users Stepper', () => {
       return manageUsersPage.waitForPage();
     });
   });
+
+  const timeout = 100000;
+  extendE2ETestTime(timeout);
 
   it('Check flow + add/remove roles ', () => {
     const stpr = manageUsersPage.stepper;
@@ -158,8 +152,8 @@ describe('Manage Users Stepper', () => {
 
     // Wait until all of the spinners have gone
     const spinners = element.all(by.tagName('mat-progress-spinner'));
-    browser.wait(function() {
-      return spinners.isPresent().then(function(present) {
+    browser.wait(function () {
+      return spinners.isPresent().then(function (present) {
         return !present;
       });
     });
@@ -173,7 +167,7 @@ describe('Manage Users Stepper', () => {
     stpr.next();
     stpr.waitUntilNotShown();
 
-  });
+  }, timeout);
 
   it('Open stepper with preselected user', () => {
     const cfPage = CfTopLevelPage.forEndpoint(cfGuid);

--- a/src/test-e2e/cloud-foundry/org-level/org-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/org-level/org-users-list-e2e.spec.ts
@@ -3,6 +3,7 @@ import { protractor } from 'protractor';
 import { e2e } from '../../e2e';
 import { CFHelpers } from '../../helpers/cf-helpers';
 import { E2EHelpers } from '../../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../../helpers/extend-test-helpers';
 import { CFUsersListComponent } from '../../po/cf-users-list.po';
 import { setUpTestOrgSpaceE2eTest } from '../users-list-e2e.helper';
 import { CfOrgLevelPage } from './cf-org-level-page.po';
@@ -31,6 +32,9 @@ describe('Org Users List -', () => {
       return orgPage.goToUsersTab();
     });
   });
+
+  const timeout = 60000;
+  extendE2ETestTime(timeout);
 
   it('Correct role pills shown, pills removed successfully', () => {
     expect(orgPage.isActivePageOrChildPage()).toBeTruthy();
@@ -75,10 +79,8 @@ describe('Org Users List -', () => {
 
     const spaceChipList = usersTable.getPermissions(userRowIndex, true);
     expect(spaceChipList.getChipElements().count()).toBe(0);
-  });
+  }, timeout);
 
 
-  afterAll(() => {
-    return cfHelper.deleteOrgIfExisting(cfGuid, orgName);
-  });
+  afterAll(() => cfHelper.deleteOrgIfExisting(cfGuid, orgName));
 });

--- a/src/test-e2e/cloud-foundry/space-level/space-users-list-e2e.spec.ts
+++ b/src/test-e2e/cloud-foundry/space-level/space-users-list-e2e.spec.ts
@@ -3,6 +3,7 @@ import { protractor } from 'protractor';
 import { e2e } from '../../e2e';
 import { CFHelpers } from '../../helpers/cf-helpers';
 import { E2EHelpers } from '../../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../../helpers/extend-test-helpers';
 import { CFUsersListComponent } from '../../po/cf-users-list.po';
 import { setUpTestOrgSpaceE2eTest } from '../users-list-e2e.helper';
 import { CfSpaceLevelPage } from './cf-space-level-page.po';
@@ -32,6 +33,9 @@ describe('Space Users List -', () => {
       return orgPage.goToUsersTab();
     });
   });
+
+  const timeout = 60000;
+  extendE2ETestTime(timeout);
 
   it('Correct role pills shown, pills removed successfully', () => {
     expect(orgPage.isActivePageOrChildPage()).toBeTruthy();
@@ -76,10 +80,8 @@ describe('Space Users List -', () => {
 
     const spaceChipList = usersTable.getPermissions(userRowIndex, true);
     expect(spaceChipList.getChipElements().count()).toBe(0);
-  });
+  }, timeout);
 
 
-  afterAll(() => {
-    return cfHelper.deleteOrgIfExisting(cfGuid, orgName);
-  });
+  afterAll(() => cfHelper.deleteOrgIfExisting(cfGuid, orgName));
 });

--- a/src/test-e2e/helpers/extend-test-helpers.ts
+++ b/src/test-e2e/helpers/extend-test-helpers.ts
@@ -1,0 +1,13 @@
+export function extendE2ETestTime(newTimeout = 140000) {
+  let originalTimeout;
+
+  // Might take a bit longer to deploy the app than the global default timeout allows
+  beforeEach(function () {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = newTimeout;
+  });
+
+  afterEach(function () {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+}

--- a/src/test-e2e/marketplace/create-service-instances-bind-app-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instances-bind-app-e2e.spec.ts
@@ -2,6 +2,7 @@ import { browser, by, ElementFinder } from 'protractor';
 
 import { e2e } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { CreateServiceInstance } from './create-service-instance.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
@@ -29,20 +30,25 @@ describe('Create Service Instance with binding', () => {
     expect(createServiceInstance.isActivePage()).toBeTruthy();
   });
 
-  it('- should be able to to create a service instance with binding', () => {
+  describe('Long running tests - ', () => {
+    const timeout = 100000;
+    extendE2ETestTime(timeout);
 
-    const servicesSecrets = e2e.secrets.getDefaultCFEndpoint().services;
-    servicesHelperE2E.createService(servicesSecrets.publicService.name, false, servicesSecrets.bindApp);
-    servicesWall.waitForPage();
+    it('- should be able to to create a service instance with binding', () => {
 
-    servicesHelperE2E.getServiceCardWithTitle(servicesWall.serviceInstancesList, servicesHelperE2E.serviceInstanceName)
-      .then(card => card.getMetaCardItems())
-      .then(metaCardRows => {
-        expect(metaCardRows[1].value).toBe(servicesSecrets.publicService.name);
-        expect(metaCardRows[2].value).toBe('shared');
-        expect(metaCardRows[3].value).toBe('1');
-      });
+      const servicesSecrets = e2e.secrets.getDefaultCFEndpoint().services;
+      servicesHelperE2E.createService(servicesSecrets.publicService.name, false, servicesSecrets.bindApp);
+      servicesWall.waitForPage();
 
+      servicesHelperE2E.getServiceCardWithTitle(servicesWall.serviceInstancesList, servicesHelperE2E.serviceInstanceName)
+        .then(card => card.getMetaCardItems())
+        .then(metaCardRows => {
+          expect(metaCardRows[1].value).toBe(servicesSecrets.publicService.name);
+          expect(metaCardRows[2].value).toBe('shared');
+          expect(metaCardRows[3].value).toBe('1');
+        });
+
+    });
   });
 
   it('- should have correct number in list view', () => {

--- a/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
@@ -2,6 +2,7 @@ import { browser } from 'protractor';
 
 import { e2e } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
+import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { ConfirmDialogComponent } from '../po/confirm-dialog';
 import { MetaCard } from '../po/meta-card.po';
 import { SideNavMenuItem } from '../po/side-nav.po';
@@ -24,6 +25,9 @@ describe('Edit Service Instance', () => {
       .getInfo();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createServiceInstance);
   });
+
+  const timeout = 100000;
+  extendE2ETestTime(timeout);
 
   beforeEach(() => {
     servicesWall.sideNav.goto(SideNavMenuItem.Services);
@@ -58,7 +62,7 @@ describe('Edit Service Instance', () => {
           servicesHelperE2E.createServiceInstance.stepper.waitUntilNotShown();
         });
       }).catch(e => fail(e));
-  });
+  }, timeout);
 
   it('- should have edited service instance', () => {
     servicesWall.waitForPage();

--- a/src/test-e2e/marketplace/services-helper-e2e.ts
+++ b/src/test-e2e/marketplace/services-helper-e2e.ts
@@ -191,9 +191,13 @@ export class ServicesHelperE2E {
         return serviceInstanceNames.findIndex(name => name === serviceInstance.entity.name) >= 0;
       });
       return serviceInstances.length ?
-        promise.all(serviceInstances.map(serviceInstance => this.deleteServiceInstance(cfGuid, serviceInstance.metadata.guid))) :
+        promise.all(serviceInstances.map(serviceInstance => this.cleanUpService(cfGuid, serviceInstance.metadata.guid))) :
         promise.fullyResolved(createEmptyCfResponse());
     });
+  }
+
+  private cleanUpService(cfGuid: string, serviceGuid: string): promise.Promise<any> {
+    return this.deleteServiceInstance(cfGuid, serviceGuid).catch(e => e2e.log(`Ignoring failed service instance delete: ${e}`));
   }
 
   getServiceCardWithTitle(list: ListComponent, serviceName: string, filter = true) {


### PR DESCRIPTION
Made new smaller effect that gets all error wrapper events and throws an internal error based on some new config.

I've also changed the routing path variable to be common across kubernetes and cf pages to make it easier for the page header to automatically pickup endpoint error states.