### PR TITLE
Optionally create kube namespace during helm install, fix kube error handling

### DIFF
--- a/custom-src/frontend/app/custom/helm/create-release/create-release.component.html
+++ b/custom-src/frontend/app/custom/helm/create-release/create-release.component.html
@@ -15,24 +15,37 @@
       <br>
       <b>Specify name and namespace for the installation</b>
       <mat-form-field>
-        <input #releaseNameInputField matInput placeholder="Name" name="releaseName" formControlName="releaseName" autocomplete="off">
+        <input #releaseNameInputField matInput placeholder="Name" name="releaseName" formControlName="releaseName"
+          autocomplete="off">
       </mat-form-field>
 
       <mat-form-field>
-        <input matInput placeholder="Namespace" name="releaseNamespace" formControlName="releaseNamespace"
-          autocomplete="off">
+        <input type="text" placeholder="Namespace" matInput formControlName="releaseNamespace" [matAutocomplete]="auto">
+        <mat-autocomplete #auto="matAutocomplete">
+          <mat-option *ngFor="let namespace of namespaces$ | async" [value]="namespace">
+            {{namespace}}
+          </mat-option>
+        </mat-autocomplete>
+        <mat-error *ngIf="details.controls.releaseNamespace.errors?.namespaceDoesNotExist">
+          Namespace does not exist
+        </mat-error>
       </mat-form-field>
+
+      <mat-checkbox matInput formControlName="createNamespace">Create Namespace</mat-checkbox>
+
     </form>
   </app-step>
   <app-step [title]="'Overrides'" [onNext]="submit" [finishButtonText]="'Install'" [onEnter]="onEnterOverrides">
     <form [formGroup]="overrides" class="stepper-form overrides_form">
       <div class="helm-create-release__heading">
         <h3 class="helm-create-release__title">Enter YAML Value Overrides</h3>
-        <button (click)="useValuesYaml()" [disabled]="!valuesYaml" class="helm-create-release__button" mat-button color="primary">Copy from values.yaml</button>
+        <button (click)="useValuesYaml()" [disabled]="!valuesYaml" class="helm-create-release__button" mat-button
+          color="primary">Copy from values.yaml</button>
       </div>
       <mat-form-field [floatLabel]="'always'" class="overrides_form-field">
         <mat-label>Values</mat-label>
-        <textarea #overridesYamlTextArea class="overrides__yaml" matInput formControlName="values" name="Values"  spellcheck="false"></textarea>
+        <textarea #overridesYamlTextArea class="overrides__yaml" matInput formControlName="values" name="Values"
+          spellcheck="false"></textarea>
       </mat-form-field>
     </form>
   </app-step>

--- a/custom-src/frontend/app/custom/helm/create-release/create-release.component.html
+++ b/custom-src/frontend/app/custom/helm/create-release/create-release.component.html
@@ -21,7 +21,7 @@
 
       <mat-form-field>
         <input type="text" placeholder="Namespace" matInput formControlName="releaseNamespace" [matAutocomplete]="auto">
-        <mat-autocomplete #auto="matAutocomplete">
+        <mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption>
           <mat-option *ngFor="let namespace of namespaces$ | async" [value]="namespace">
             {{namespace}}
           </mat-option>

--- a/custom-src/frontend/app/custom/helm/create-release/create-release.component.scss
+++ b/custom-src/frontend/app/custom/helm/create-release/create-release.component.scss
@@ -19,6 +19,12 @@
 
 form {
   flex: 1;
+
+  mat-checkbox {
+    display: flex;
+    height: 23px;
+    margin-top: 10px;
+  }
 }
 
 .overrides {

--- a/custom-src/frontend/app/custom/helm/create-release/create-release.component.ts
+++ b/custom-src/frontend/app/custom/helm/create-release/create-release.component.ts
@@ -1,19 +1,35 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatTextareaAutosize } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { Observable, of, Subscription } from 'rxjs';
-import { delay, filter, first, map, pairwise, switchMap, tap } from 'rxjs/operators';
+import { PaginationMonitorFactory } from 'frontend/packages/store/src/monitors/pagination-monitor.factory';
+import { getPaginationObservables } from 'frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
+import {
+  delay,
+  distinctUntilChanged,
+  filter,
+  first,
+  map,
+  pairwise,
+  publishReplay,
+  refCount,
+  startWith,
+  switchMap,
+} from 'rxjs/operators';
 
 import { AppState } from '../../../../../store/src/app-state';
 import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
 import { EndpointsService } from '../../../core/endpoints.service';
+import { safeUnsubscribe } from '../../../core/utils.service';
 import { ConfirmationDialogConfig } from '../../../shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../shared/components/confirmation-dialog.service';
-import { StepOnNextFunction } from '../../../shared/components/stepper/step/step.component';
+import { StepOnNextFunction, StepOnNextResult } from '../../../shared/components/stepper/step/step.component';
 import { KUBERNETES_ENDPOINT_TYPE } from '../../kubernetes/kubernetes-entity-factory';
+import { KubernetesNamespace } from '../../kubernetes/store/kube.types';
+import { CreateKubernetesNamespace, GetKubernetesNamespaces } from '../../kubernetes/store/kubernetes.actions';
 import { helmReleaseEntityKey } from '../../kubernetes/workloads/store/workloads-entity-factory';
 import { HelmInstall } from '../store/helm.actions';
 import { HelmInstallValues } from '../store/helm.types';
@@ -23,7 +39,7 @@ import { HelmInstallValues } from '../store/helm.types';
   templateUrl: './create-release.component.html',
   styleUrls: ['./create-release.component.scss'],
 })
-export class CreateReleaseComponent implements OnInit {
+export class CreateReleaseComponent implements OnInit, OnDestroy {
 
   // Confirmation dialog
   overwriteValuesConfirmation = new ConfirmationDialogConfig(
@@ -40,7 +56,10 @@ export class CreateReleaseComponent implements OnInit {
   validate$: Observable<boolean>;
 
   details: FormGroup;
+  namespaces$: Observable<string[]>;
   overrides: FormGroup;
+
+  private endpointChanged = new BehaviorSubject(null);
 
   @ViewChild('releaseNameInputField', { static: true }) releaseNameInputField: ElementRef;
   @ViewChild('overridesYamlTextArea', { static: true }) overridesYamlTextArea: ElementRef;
@@ -48,44 +67,109 @@ export class CreateReleaseComponent implements OnInit {
 
   public valuesYaml = '';
 
+  private subs: Subscription[] = [];
+
   constructor(
     private route: ActivatedRoute,
     public endpointsService: EndpointsService,
     private store: Store<AppState>,
     private httpClient: HttpClient,
     private confirmDialog: ConfirmationDialogService,
-    // private esf: EntityServiceFactory
+    private pmf: PaginationMonitorFactory
   ) {
     const chart = this.route.snapshot.params;
     this.cancelUrl = `/monocular/charts/${chart.repo}/${chart.chartName}/${chart.version}`;
 
-    this.kubeEndpoints$ = this.endpointsService.connectedEndpointsOfTypes(KUBERNETES_ENDPOINT_TYPE);
-
-    this.details = new FormGroup({
-      endpoint: new FormControl('', Validators.required),
-      releaseName: new FormControl('', Validators.required),
-      releaseNamespace: new FormControl('', Validators.required),
-    });
+    this.setupDetailsStep();
 
     this.overrides = new FormGroup({
       values: new FormControl('')
     });
 
-    this.validate$ = this.details.statusChanges.pipe(
-      map(() => this.details.valid)
-    );
-
     // Fetch the values.yaml for the Chart
     const valuesYamlUrl = `/pp/v1/chartsvc/v1/assets/${chart.repo}/${chart.chartName}/versions/${chart.version}/values.yaml`;
 
+    // TODO: RC Error handling
     this.httpClient.get(valuesYamlUrl, { responseType: 'text' }).subscribe(response => {
       this.valuesYaml = response;
     });
   }
 
+  private setupDetailsStep() {
+    this.kubeEndpoints$ = this.endpointsService.connectedEndpointsOfTypes(KUBERNETES_ENDPOINT_TYPE);
+
+    this.namespaces$ = this.endpointChanged.asObservable().pipe(
+      switchMap(endpoint => {
+        const action = new GetKubernetesNamespaces(endpoint);
+        return getPaginationObservables<KubernetesNamespace>({
+          store: this.store,
+          action,
+          paginationMonitor: this.pmf.create(action.paginationKey, action)
+        }).entities$;
+      }),
+      map((namespaces: KubernetesNamespace[]) => namespaces.map(namespace => namespace.metadata.name)),
+      publishReplay(1),
+      refCount(),
+    );
+
+    this.details = new FormGroup({
+      endpoint: new FormControl('', Validators.required),
+      releaseName: new FormControl('', Validators.required),
+      releaseNamespace: new FormControl(''),
+      createNamespace: new FormControl(false),
+    });
+    this.details.controls.createNamespace.disable();
+
+    const namespaceChanged$ = this.details.controls.releaseNamespace.valueChanges.pipe(
+      distinctUntilChanged()
+    );
+    const createNamespaceChanged$ = this.details.controls.createNamespace.valueChanges.pipe(
+      startWith(false),
+      distinctUntilChanged()
+    );
+
+    this.subs.push(
+      combineLatest([
+        this.namespaces$,
+        namespaceChanged$,
+        createNamespaceChanged$
+      ])
+        .pipe().subscribe(([namespaces, namespace, create]) => {
+          const namespaceExists = !!namespaces.find(val => val === namespace);
+          if (namespaceExists) {
+            // All is fine
+            this.details.controls.releaseNamespace.validator = () => null;
+            this.details.controls.createNamespace.setValue(false);
+            this.details.controls.createNamespace.disable();
+          } else if (!namespace) {
+            // Invalid - missing namespace
+            this.details.controls.releaseNamespace.validator = () => ({ required: true });
+            this.details.controls.createNamespace.disable();
+          } else if (!create) {
+            // Invalid - namespace doesn't exist and not creating
+            this.details.controls.releaseNamespace.validator = () => ({ namespaceDoesNotExist: true });
+            this.details.controls.createNamespace.enable();
+          } else {
+            // Valid - namespace doesn't exist but creating
+            this.details.controls.releaseNamespace.validator = () => null;
+            // this.details.controls.createNamespace.disable();
+          }
+          this.details.controls.releaseNamespace.updateValueAndValidity();
+        })
+    );
+
+    this.subs.push(
+      this.details.controls.endpoint.valueChanges.subscribe(val => {
+        this.endpointChanged.next(val);
+      })
+    );
+
+    this.validate$ = this.details.statusChanges.pipe(
+      map(() => this.details.valid)
+    );
+  }
+
   public useValuesYaml() {
-
-
     if (this.overrides.value.values.length !== 0) {
       this.confirmDialog.open(this.overwriteValuesConfirmation, () => {
         this.replaceWithValuesYaml();
@@ -102,17 +186,15 @@ export class CreateReleaseComponent implements OnInit {
 
   ngOnInit() {
     // Auto select endpoint if there is only one
-    this.kubeEndpoints$.pipe(
-      first(),
-      tap(ep => {
-        if (ep.length === 1) {
-          this.details.controls.endpoint.setValue(ep[0].guid, { onlySelf: true });
-          setTimeout(() => {
-            this.releaseNameInputField.nativeElement.focus();
-          }, 1);
-        }
-      })
-    ).subscribe();
+    this.kubeEndpoints$.pipe(first()).subscribe(ep => {
+      if (ep.length > 1) {
+        this.details.controls.endpoint.setValue(ep[0].guid, { onlySelf: true });
+        this.endpointChanged.next(ep[0].guid);
+        setTimeout(() => {
+          this.releaseNameInputField.nativeElement.focus();
+        }, 1);
+      }
+    });
   }
 
   onEnterOverrides = () => {
@@ -123,6 +205,28 @@ export class CreateReleaseComponent implements OnInit {
   }
 
   submit: StepOnNextFunction = () => {
+
+    const createNamespace$ = this.details.controls.createNamespace.value ? this.createNamespace() : of({ success: true });
+
+    return createNamespace$.pipe(
+      switchMap(createRes => {
+        if (!createRes.success) {
+          return createRes;
+        }
+        return this.installChart();
+      })
+    );
+  }
+
+  createNamespace(): Observable<StepOnNextResult> {
+    // TODO: RC namespace exists from previous run??
+    const action = new CreateKubernetesNamespace();
+    return of({
+      success: false
+    });
+  }
+
+  installChart(): Observable<StepOnNextResult> {
     // Build the request body
     const values: HelmInstallValues = {
       ...this.details.value,
@@ -154,7 +258,10 @@ export class CreateReleaseComponent implements OnInit {
         message: !result.error ? '' : result.message
       })),
     );
+  }
 
+  ngOnDestroy() {
+    safeUnsubscribe(...this.subs);
   }
 
 }

--- a/custom-src/frontend/app/custom/helm/store/helm.effects.ts
+++ b/custom-src/frontend/app/custom/helm/store/helm.effects.ts
@@ -68,7 +68,6 @@ export class HelmEffects {
     flatMap(action => {
       const entityKey = entityCatalog.getEntityKey(action);
       return this.makeRequest(action, `/pp/${this.proxyAPIVersion}/helm/versions`, (response) => {
-        // const a: HelmVersion = {};
         const processedData = {
           entities: { [entityKey]: {} },
           result: []
@@ -116,7 +115,6 @@ export class HelmEffects {
           ];
         })
       );
-
     })
   );
 

--- a/custom-src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
+++ b/custom-src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
@@ -1,5 +1,6 @@
 import { SortDirection } from '@angular/material';
 import { getActions } from 'frontend/packages/store/src/actions/action.helper';
+import { ApiRequestTypes } from 'frontend/packages/store/src/reducers/api-request-reducer/request-helpers';
 
 import { MetricQueryConfig, MetricsAction, MetricsChartAction } from '../../../../../store/src/actions/metrics.actions';
 import { getPaginationKey } from '../../../../../store/src/actions/pagination.actions';
@@ -170,6 +171,7 @@ export class CreateKubernetesNamespace implements KubeAction {
   endpointType = KUBERNETES_ENDPOINT_TYPE;
   entity = [kubernetesEntityFactory(kubernetesNamespacesEntityType)];
   actions = getActions('Namespace', 'Create');
+  requestType: ApiRequestTypes = 'create';
 }
 
 export class GetKubernetesPods implements KubePaginationAction {

--- a/custom-src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
+++ b/custom-src/frontend/app/custom/kubernetes/store/kubernetes.actions.ts
@@ -1,4 +1,5 @@
 import { SortDirection } from '@angular/material';
+import { getActions } from 'frontend/packages/store/src/actions/action.helper';
 
 import { MetricQueryConfig, MetricsAction, MetricsChartAction } from '../../../../../store/src/actions/metrics.actions';
 import { getPaginationKey } from '../../../../../store/src/actions/pagination.actions';
@@ -51,6 +52,8 @@ export const GET_NAMESPACES_INFO_FAILURE = '[KUBERNETES Endpoint] Get Namespaces
 export const GET_NAMESPACE_INFO = '[KUBERNETES Endpoint] Get Namespace Info';
 export const GET_NAMESPACE_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Namespace Info Success';
 export const GET_NAMESPACE_INFO_FAILURE = '[KUBERNETES Endpoint] Get Namespace Info Failure';
+
+export const CREATE_NAMESPACE = '[KUBERNETES Endpoint] Create Namespace';
 
 export const GET_KUBERNETES_APP_INFO = '[KUBERNETES Endpoint] Get Kubernetes App Info';
 export const GET_KUBERNETES_APP_INFO_SUCCESS = '[KUBERNETES Endpoint] Get Kubernetes App Info Success';
@@ -156,6 +159,19 @@ export class GetKubernetesNamespace implements KubeAction {
   ];
 }
 
+export class CreateKubernetesNamespace implements KubeAction {
+  public guid: string;
+  constructor(public namespaceName: string, public kubeGuid: string) {
+    this.guid = `Creating-${namespaceName}-${kubeGuid}`;
+  }
+
+  type = CREATE_NAMESPACE;
+  entityType = kubernetesNamespacesEntityType;
+  endpointType = KUBERNETES_ENDPOINT_TYPE;
+  entity = [kubernetesEntityFactory(kubernetesNamespacesEntityType)];
+  actions = getActions('Namespace', 'Create');
+}
+
 export class GetKubernetesPods implements KubePaginationAction {
   constructor(public kubeGuid) {
     this.paginationKey = getPaginationKey(kubernetesPodsEntityType, 'k8', kubeGuid);
@@ -235,7 +251,7 @@ export class GetKubernetesPodsInNamespace implements PaginatedAction, KubeAction
 }
 
 export class GetKubernetesNamespaces implements KubePaginationAction {
-  constructor(public kubeGuid) {
+  constructor(public kubeGuid: string) {
     this.paginationKey = getPaginationKey(kubernetesNamespacesEntityType, kubeGuid || 'all');
   }
   type = GET_NAMESPACES_INFO;
@@ -365,3 +381,5 @@ export class FetchKubernetesChartMetricsAction extends MetricsChartAction {
     );
   }
 }
+
+

--- a/src/frontend/packages/core/src/jetstream.helpers.ts
+++ b/src/frontend/packages/core/src/jetstream.helpers.ts
@@ -14,6 +14,16 @@ export interface JetStreamErrorResponse<T = any> {
   errorResponse: T;
 }
 
+export function isJetstreamError(err: any): JetStreamErrorResponse {
+  return !!(
+    err &&
+    err.error &&
+    err.error.status &&
+    err.error.statusCode &&
+    'errorResponse' in err
+  ) ? err as JetStreamErrorResponse : null;
+}
+
 // TODO It would be nice if the BE could return a unique para for us to check for. #3827
 // There is always a chance that this will return a false positive (more so with extensions).
 export function hasJetStreamError(pages: Partial<JetStreamErrorResponse>[]): JetStreamErrorResponse {
@@ -21,13 +31,7 @@ export function hasJetStreamError(pages: Partial<JetStreamErrorResponse>[]): Jet
     return null;
   }
   return pages.find(page => {
-    return !!(
-      page &&
-      page.error &&
-      page.error.status &&
-      page.error.statusCode &&
-      'errorResponse' in page
-    );
+    return isJetstreamError(page);
   }) as JetStreamErrorResponse;
 }
 


### PR DESCRIPTION
- Blocked on #267
- Allow user to select from existing namespaces or create one
- Fix kube error handling
  - We were expecting the error to be thrown instead of wrapped in jetstream 200 and errors in response per endpoint