### PR TITLE
Only fetch first page of maxed lists

### DIFF
--- a/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
+++ b/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
@@ -84,7 +84,8 @@ export class PaginationPageIterator<R = any, E = any> {
     }, {} as PagedJetstreamResponse);
   }
 
-  private handleRequests(initialResponse: JetstreamResponse<R>, action: PaginatedAction, totalPages: number, totalResults: number) {
+  private handleRequests(initialResponse: JetstreamResponse<R>, action: PaginatedAction, totalPages: number, totalResults: number):
+    Observable<[JetstreamResponse<R>, JetstreamResponse<R>[]]> {
     if (totalResults > 0) {
       const maxCount = action.flattenPaginationMax;
       // We're maxed so only respond with the first page of results.
@@ -94,7 +95,7 @@ export class PaginationPageIterator<R = any, E = any> {
         this.actionDispatcher(
           new UpdatePaginationMaxedState(maxCount, totalResults, entityType, endpointType, paginationKey, forcedEntityKey)
         );
-        of([initialResponse]);
+        return of([initialResponse, []]);
       }
     }
     return combineLatest(of(initialResponse), this.getAllOtherPageRequests(totalPages));


### PR DESCRIPTION
- Missing return meant we still fetched remaining pages
- This means lists are marked as busy until all pages are fetched, even though the list is displayed as maxed
- Port of https://github.com/cloudfoundry/stratos/pull/4138