### PR TITLE
Release pipeline fix

### DIFF
--- a/deploy/ci/suse-console-dev-releases.yml
+++ b/deploy/ci/suse-console-dev-releases.yml
@@ -6,7 +6,6 @@ resource_types:
   privileged: true
   source:
     repository: ((docker-resource-image))
-    tag: ((docker-resource-image-tag))
 resources:
 # Stratos Git Repository
 - name: stratos


### PR DESCRIPTION
tag: "latest" breaks latest Concourse - its the default anyway, so remove it