### PR TITLE
Set memory limits for stratos-chartstore fdbdoclayer container

### DIFF
--- a/deploy/kubernetes/console/templates/fdbdoclayer/deployment.yaml
+++ b/deploy/kubernetes/console/templates/fdbdoclayer/deployment.yaml
@@ -86,6 +86,11 @@ spec:
         - name: certs
           mountPath: "/etc/secrets"
           readOnly: true
+        resources:
+          limits:
+            memory: 384Mi
+          requests:
+            memory: 256Mi
       - name: fdbserver
         image: {{.Values.kube.registry.hostname}}/{{.Values.kube.organization}}/{{.Values.images.fdbserver}}:{{.Values.consoleVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}


### PR DESCRIPTION
- fixes #429
- apply limit to container showing memory leak
- resources cannot be set in deployment's spec (`DeploymentSpec` does not support `resources` - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentspec-v1-apps)
