### PR TITLE
Fix helm 3 lint issue

### DIFF
--- a/deploy/kubernetes/console/templates/analyzers.yaml
+++ b/deploy/kubernetes/console/templates/analyzers.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.console.techPreview }}
+---
 {{- if semverCompare ">=1.16" (printf "%s.%s" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor) )}}
 apiVersion: apps/v1
 {{- else }}


### PR DESCRIPTION
Fixes linting issue with Helm 3:

```
==> Linting ./helm-chart/
[ERROR] templates/analyzers.yaml: object name does not conform to Kubernetes naming requirements: ""

Error: 1 chart(s) linted, 1 chart(s) failed
```