### PR TITLE
Fix bug where CF cells page was empty

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
@@ -32,12 +32,7 @@ export class CfCellsDataSource
       paginationKey: action.paginationKey,
       isLocal: true,
       transformEntities: [{ type: 'filter', field: CfCellsDataSource.cellIdPath }],
-      transformEntity: map((response) => {
-        if (!response || response.length === 0) {
-          return [];
-        }
-        return [...response[0].data.result];
-      }),
+      transformEntity: map((response) => [...(response?.[0]?.data?.result || [])]),
       listConfig
     });
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-cells/cf-cells-data-source.ts
@@ -36,7 +36,7 @@ export class CfCellsDataSource
         if (!response || response.length === 0) {
           return [];
         }
-        return response[0].data.result;
+        return [...response[0].data.result];
       }),
       listConfig
     });


### PR DESCRIPTION
Fixes bug where the Cells info for a Cloud Foundry is empty because the array is not mutable, so the sorting/filtering functions can not mutate the array.