### PR TITLE
Fix user profile page

### DIFF
--- a/src/frontend/packages/store/src/actions/user-profile.actions.ts
+++ b/src/frontend/packages/store/src/actions/user-profile.actions.ts
@@ -8,7 +8,7 @@ export const UPDATE_USERPROFILE = '[UserProfile] Update';
 export const UPDATE_USERPASSWORD = '[UserPassword] Update';
 
 abstract class BaseProfileAction implements EntityRequestAction {
-  static guid = 'userProfile';
+  static guid = userProfileEntityType;
   guid = BaseProfileAction.guid;
   entityType = userProfileEntityType;
   endpointType = STRATOS_ENDPOINT_TYPE;

--- a/src/frontend/packages/store/src/helpers/stratos-entity-factory.ts
+++ b/src/frontend/packages/store/src/helpers/stratos-entity-factory.ts
@@ -30,6 +30,7 @@ const EndpointSchema = new StratosEntitySchema(endpointEntityType, 'guid');
 entityCache[endpointEntityType] = EndpointSchema;
 
 const UserProfileInfoSchema = new StratosEntitySchema(userProfileEntityType, 'id');
+UserProfileInfoSchema.getId = () => userProfileEntityType;
 entityCache[userProfileEntityType] = UserProfileInfoSchema;
 
 const ApiKeySchema = new StratosEntitySchema(apiKeyEntityType, 'guid');


### PR DESCRIPTION
- there's only ever one user profile, this was hardcoded to be `userProfile` (see user profile action)
- ensure that the user profile schema uses the hardcoded id when determining the id of an entity
