### PR TITLE
Fix application of `maxed` lists following page refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ jobs:
     - name: Backend Lint
       before_script:
         - "./deploy/ci/travis/install-go.sh"
-        - go get -u golang.org/x/lint/golint
+        - export GO111MODULE=on
+        - go get golang.org/x/lint/golint@v0.0.0-20190909230951-414d861bb4ac
       script:
         - golint src/jetstream/...
         - ./deploy/ci/travis/update-go-report-card.sh

--- a/src/frontend/packages/core/src/shared/components/list/list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.ts
@@ -22,6 +22,7 @@ import { Store } from '@ngrx/store';
 import {
   asapScheduler,
   BehaviorSubject,
+  combineLatest,
   combineLatest as observableCombineLatest,
   isObservable,
   Observable,
@@ -39,6 +40,7 @@ import {
   refCount,
   startWith,
   subscribeOn,
+  switchMap,
   takeWhile,
   tap,
   withLatestFrom,
@@ -468,7 +470,13 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
     // - Pass any multi filter changes made by the user to the pagination controller and thus the store
     // - If the first multi filter has one value it's not shown, ensure it's automatically selected to ensure other filters are correct
     this.multiFilterWidgetObservables = new Array<Subscription>();
-    this.paginationController.filter$.pipe(
+
+    combineLatest(this.multiFilterManagers.map(mfm => {
+      // Use this instead of filterIsReady$ to ensure the drop downs report as ready even when there's nothing to select
+      return mfm.filterIsInitialised$
+    })).pipe(
+      filter(firs => firs.every(ready => ready)),
+      switchMap(() => this.paginationController.filter$),
       first(),
       tap(() => {
         Object.values(this.multiFilterManagers).forEach((filterManager: MultiFilterManager<T>, index: number) => {

--- a/src/frontend/packages/core/src/shared/components/list/list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.ts
@@ -473,7 +473,7 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
 
     combineLatest(this.multiFilterManagers.map(mfm => {
       // Use this instead of filterIsReady$ to ensure the drop downs report as ready even when there's nothing to select
-      return mfm.filterIsInitialised$
+      return mfm.filterIsInitialised$;
     })).pipe(
       filter(firs => firs.every(ready => ready)),
       switchMap(() => this.paginationController.filter$),

--- a/src/frontend/packages/store/src/helpers/local-storage-service.ts
+++ b/src/frontend/packages/store/src/helpers/local-storage-service.ts
@@ -173,7 +173,8 @@ export class LocalStorageService {
               params: paginationSection.params,
               clientPagination: paginationSection.clientPagination,
               isListPagination: paginationSection.isListPagination, // We do not persist any that are false
-              forcedLocalPage: paginationSection.forcedLocalPage // Value of the multi-entity filter
+              forcedLocalPage: paginationSection.forcedLocalPage, // Value of the multi-entity filter
+              maxedState: paginationSection.maxedState // Persist this state, so the console knows to set q params on filter change (means user is stuck in max'd view)
             };
             return res2;
           }, {});

--- a/src/frontend/packages/store/src/helpers/local-storage-service.ts
+++ b/src/frontend/packages/store/src/helpers/local-storage-service.ts
@@ -174,7 +174,8 @@ export class LocalStorageService {
               clientPagination: paginationSection.clientPagination,
               isListPagination: paginationSection.isListPagination, // We do not persist any that are false
               forcedLocalPage: paginationSection.forcedLocalPage, // Value of the multi-entity filter
-              maxedState: paginationSection.maxedState // Persist this state, so the console knows to set q params on filter change (means user is stuck in max'd view)
+              // Persist this state, so the console knows to set q params on filter change (means user is stuck in max'd view)
+              maxedState: paginationSection.maxedState
             };
             return res2;
           }, {});


### PR DESCRIPTION
Fixes https://github.com/SUSE/stratos/issues/560

Issue
- When there are too many resources to show in a list we enter `max` state
- When in max'd state we force the user to select filters to restrict the number of results (changing filters results in new http requests with the filters)
- We persist the state of the list to local storage. This includes filters but does not include the `max` flag
- When the user re-visits the list after page refresh instead of fetching all resources we only fetch those applicable to the filter (which will be a small subset of all resources). As the `max` flag isn't persisted we assume we've fetched all resources. Any changes to the filter are then applied locally to the subset of resources... which may not contain any applicable to the new filter

Fix
- Persist the list's `max` state such that when the list loads again all filter changes correctly result in http requests
- This needed a fix in the way we watch the filters for changes (we block this watch until all filters report as ready)
- Fix downside
  - Lists cannot ever leave the `max` state. All changes to filters will result in http requests. User would need to clear their local cache to reset the list (we have a button for this in the user's profile page)

Tested
- Different types of org/space filter setups
  - orgs with no spaces
  - orgs with some spaces under maxed, some over
- Different types of lists
- Tested with UI_LIST_ALLOW_LOAD_MAXED true (allow user to overrule maxed state and fetch everything)